### PR TITLE
tag created EC instances with environment

### DIFF
--- a/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -92,6 +92,7 @@ export async function createRunner(runnerParameters: RunnerInputParameters): Pro
               Key: runnerParameters.orgName ? 'Org' : 'Repo',
               Value: runnerParameters.orgName ? runnerParameters.orgName : runnerParameters.repoName,
             },
+            { Key: 'Environment', Value: runnerParameters.environment },
           ],
         },
       ],


### PR DESCRIPTION
Created EC2 instances were not tagged with the environment.

However, the instance-number limitation and downscaling only considers EC2 instances with a correct 'Environment' tag.

-> This pull request adds the 'Environment' tag to created EC2 instances
-> Fixes the instance number limitation
-> Fixes downscaling