### PR TITLE
Add ability to override instance_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,55 +224,55 @@ The following sub modules are optional and are provided as example or utility:
 - _[setup-iam-permissions](./modules/setup-iam-permissions/README.md)_ - Example module to setup permission boundaries
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Requirements
 
 No requirements.
 
 ## Providers
 
-| Name   | Version |
-| ------ | ------- |
-| aws    | n/a     |
-| random | n/a     |
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| random | n/a |
 
 ## Inputs
 
-| Name                                  | Description                                                                                                                                                                                                   | Type                                                                                                                                             | Default                 | Required |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | :------: |
-| aws_region                            | AWS region.                                                                                                                                                                                                   | `string`                                                                                                                                         | n/a                     |   yes    |
-| enable_organization_runners           | n/a                                                                                                                                                                                                           | `bool`                                                                                                                                           | n/a                     |   yes    |
-| encrypt_secrets                       | Encrypt secret variables for lambda's such as secrets and private keys.                                                                                                                                       | `bool`                                                                                                                                           | `true`                  |    no    |
-| environment                           | A name that identifies the environment, used as prefix and for tagging.                                                                                                                                       | `string`                                                                                                                                         | n/a                     |   yes    |
-| github_app                            | GitHub app parameters, see your github aapp. Ensure the key is base64 encoded.                                                                                                                                | <pre>object({<br> key_base64 = string<br> id = string<br> client_id = string<br> client_secret = string<br> webhook_secret = string<br> })</pre> | n/a                     |   yes    |
-| instance_profile_path                 | The path that will be added to the instance_profile, if not set the environment name will be used.                                                                                                            | `string`                                                                                                                                         | `null`                  |    no    |
-| kms_key_id                            | Custom KMS key to encrypted lambda secrets, if not provided and `encrypt_secrets` = `true` a KMS key will be created by the module. Secrets will be encrypted with a context `Environment = var.environment`. | `string`                                                                                                                                         | `null`                  |    no    |
-| manage_kms_key                        | Let the module manage the KMS key.                                                                                                                                                                            | `bool`                                                                                                                                           | `true`                  |    no    |
-| minimum_running_time_in_minutes       | The time an ec2 action runner should be running at minium before terminated if non busy.                                                                                                                      | `number`                                                                                                                                         | `5`                     |    no    |
-| role_path                             | The path that will be added to role path for created roles, if not set the environment name will be used.                                                                                                     | `string`                                                                                                                                         | `null`                  |    no    |
-| role_permissions_boundary             | Permissions boundary that will be added to the created roles.                                                                                                                                                 | `string`                                                                                                                                         | `null`                  |    no    |
-| runner_as_root                        | Run the action runner under the root user.                                                                                                                                                                    | `bool`                                                                                                                                           | `false`                 |    no    |
-| runner_binaries_syncer_lambda_timeout | Time out of the binaries sync lambda in seconds.                                                                                                                                                              | `number`                                                                                                                                         | `300`                   |    no    |
-| runner_binaries_syncer_lambda_zip     | File location of the binaries sync lambda zip file.                                                                                                                                                           | `string`                                                                                                                                         | `null`                  |    no    |
-| runner_extra_labels                   | Extra labels for the runners (GitHub). Separate each label by a comma                                                                                                                                         | `string`                                                                                                                                         | `""`                    |    no    |
-| runners_lambda_zip                    | File location of the lambda zip file for scaling runners.                                                                                                                                                     | `string`                                                                                                                                         | `null`                  |    no    |
-| runners_maxiumum_count                | The maxiumum number of runners tha will be created.                                                                                                                                                           | `number`                                                                                                                                         | `3`                     |    no    |
-| runners_scale_down_lambda_timeout     | Time out for the scale up lambda in seconds.                                                                                                                                                                  | `number`                                                                                                                                         | `60`                    |    no    |
-| runners_scale_up_lambda_timeout       | Time out for the scale down lambda in seconds.                                                                                                                                                                | `number`                                                                                                                                         | `60`                    |    no    |
-| scale_down_schedule_expression        | Scheduler expression to check every x for scale down.                                                                                                                                                         | `string`                                                                                                                                         | `"cron(*/5 * * * ? *)"` |    no    |
-| subnet_ids                            | List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_id`.                                                                                                | `list(string)`                                                                                                                                   | n/a                     |   yes    |
-| tags                                  | Map of tags that will be added to created resources. By default resources will be tagged with name and environment.                                                                                           | `map(string)`                                                                                                                                    | `{}`                    |    no    |
-| vpc_id                                | The VPC for security groups of the action runners.                                                                                                                                                            | `string`                                                                                                                                         | n/a                     |   yes    |
-| webhook_lambda_timeout                | Time out of the webhook lambda in seconds.                                                                                                                                                                    | `number`                                                                                                                                         | `10`                    |    no    |
-| webhook_lambda_zip                    | File location of the wehbook lambda zip file.                                                                                                                                                                 | `string`                                                                                                                                         | `null`                  |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| aws\_region | AWS region. | `string` | n/a | yes |
+| enable\_organization\_runners | n/a | `bool` | n/a | yes |
+| encrypt\_secrets | Encrypt secret variables for lambda's such as secrets and private keys. | `bool` | `true` | no |
+| environment | A name that identifies the environment, used as prefix and for tagging. | `string` | n/a | yes |
+| github\_app | GitHub app parameters, see your github aapp. Ensure the key is base64 encoded. | <pre>object({<br>    key_base64     = string<br>    id             = string<br>    client_id      = string<br>    client_secret  = string<br>    webhook_secret = string<br>  })</pre> | n/a | yes |
+| instance\_profile\_path | The path that will be added to the instance\_profile, if not set the environment name will be used. | `string` | `null` | no |
+| instance\_type | Instance type for the action runner. | `string` | `"m5.large"` | no |
+| kms\_key\_id | Custom KMS key to encrypted lambda secrets, if not provided and `encrypt_secrets` = `true` a KMS key will be created by the module. Secrets will be encrypted with a context `Environment = var.environment`. | `string` | `null` | no |
+| manage\_kms\_key | Let the module manage the KMS key. | `bool` | `true` | no |
+| minimum\_running\_time\_in\_minutes | The time an ec2 action runner should be running at minium before terminated if non busy. | `number` | `5` | no |
+| role\_path | The path that will be added to role path for created roles, if not set the environment name will be used. | `string` | `null` | no |
+| role\_permissions\_boundary | Permissions boundary that will be added to the created roles. | `string` | `null` | no |
+| runner\_as\_root | Run the action runner under the root user. | `bool` | `false` | no |
+| runner\_binaries\_syncer\_lambda\_timeout | Time out of the binaries sync lambda in seconds. | `number` | `300` | no |
+| runner\_binaries\_syncer\_lambda\_zip | File location of the binaries sync lambda zip file. | `string` | `null` | no |
+| runner\_extra\_labels | Extra labels for the runners (GitHub). Separate each label by a comma | `string` | `""` | no |
+| runners\_lambda\_zip | File location of the lambda zip file for scaling runners. | `string` | `null` | no |
+| runners\_maxiumum\_count | The maxiumum number of runners tha will be created. | `number` | `3` | no |
+| runners\_scale\_down\_lambda\_timeout | Time out for the scale up lambda in seconds. | `number` | `60` | no |
+| runners\_scale\_up\_lambda\_timeout | Time out for the scale down lambda in seconds. | `number` | `60` | no |
+| scale\_down\_schedule\_expression | Scheduler expression to check every x for scale down. | `string` | `"cron(*/5 * * * ? *)"` | no |
+| subnet\_ids | List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_id`. | `list(string)` | n/a | yes |
+| tags | Map of tags that will be added to created resources. By default resources will be tagged with name and environment. | `map(string)` | `{}` | no |
+| vpc\_id | The VPC for security groups of the action runners. | `string` | n/a | yes |
+| webhook\_lambda\_timeout | Time out of the webhook lambda in seconds. | `number` | `10` | no |
+| webhook\_lambda\_zip | File location of the wehbook lambda zip file. | `string` | `null` | no |
 
 ## Outputs
 
-| Name            | Description |
-| --------------- | ----------- |
-| binaries_syncer | n/a         |
-| runners         | n/a         |
-| webhook         | n/a         |
+| Name | Description |
+|------|-------------|
+| binaries\_syncer | n/a |
+| runners | n/a |
+| webhook | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,8 @@ module "runners" {
   s3_bucket_runner_binaries   = module.runner_binaries.bucket
   s3_location_runner_binaries = local.s3_action_runner_url
 
+  instance_type = var.instance_type
+
   sqs_build_queue                 = aws_sqs_queue.queued_builds
   github_app                      = var.github_app
   enable_organization_runners     = var.enable_organization_runners

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,12 @@ variable "instance_profile_path" {
   default     = null
 }
 
+variable "instance_type" {
+  description = "Instance type for the action runner."
+  type        = string
+  default     = "m5.large"
+}
+
 variable "runner_as_root" {
   description = "Run the action runner under the root user."
   type        = bool


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.

### Issue Endorsed by Maintainers

N/A

### Description of the Change

The current situation is that the module doesn't allow overriding the instance type, the change adds a variable to the module so that this can be achieved.

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process

Setting the `instance_type` module argument should yield a change in the module's `aws_launch_template` `runner` resource.

### Release Notes

- Add the ability to override default runner instance type.
