### PR TITLE
Rename variable and fix variables descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ No requirements.
 | runner\_binaries\_syncer\_lambda\_zip | File location of the binaries sync lambda zip file. | `string` | `null` | no |
 | runner\_extra\_labels | Extra labels for the runners (GitHub). Separate each label by a comma | `string` | `""` | no |
 | runners\_lambda\_zip | File location of the lambda zip file for scaling runners. | `string` | `null` | no |
-| runners\_maxiumum\_count | The maxiumum number of runners tha will be created. | `number` | `3` | no |
+| runners\_maximum\_count | The maximum number of runners tha will be created. | `number` | `3` | no |
 | runners\_scale\_down\_lambda\_timeout | Time out for the scale up lambda in seconds. | `number` | `60` | no |
 | runners\_scale\_up\_lambda\_timeout | Time out for the scale down lambda in seconds. | `number` | `60` | no |
 | scale\_down\_schedule\_expression | Scheduler expression to check every x for scale down. | `string` | `"cron(*/5 * * * ? *)"` | no |

--- a/README.md
+++ b/README.md
@@ -257,8 +257,8 @@ No requirements.
 | runner\_extra\_labels | Extra labels for the runners (GitHub). Separate each label by a comma | `string` | `""` | no |
 | runners\_lambda\_zip | File location of the lambda zip file for scaling runners. | `string` | `null` | no |
 | runners\_maximum\_count | The maximum number of runners tha will be created. | `number` | `3` | no |
-| runners\_scale\_down\_lambda\_timeout | Time out for the scale up lambda in seconds. | `number` | `60` | no |
-| runners\_scale\_up\_lambda\_timeout | Time out for the scale down lambda in seconds. | `number` | `60` | no |
+| runners\_scale\_down\_lambda\_timeout | Time out for the scale down lambda in seconds. | `number` | `60` | no |
+| runners\_scale\_up\_lambda\_timeout | Time out for the scale up lambda in seconds. | `number` | `60` | no |
 | scale\_down\_schedule\_expression | Scheduler expression to check every x for scale down. | `string` | `"cron(*/5 * * * ? *)"` | no |
 | subnet\_ids | List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_id`. | `list(string)` | n/a | yes |
 | tags | Map of tags that will be added to created resources. By default resources will be tagged with name and environment. | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ module "runners" {
   minimum_running_time_in_minutes = var.minimum_running_time_in_minutes
   runner_extra_labels             = var.runner_extra_labels
   runner_as_root                  = var.runner_as_root
-  runners_maxiumum_count          = var.runners_maxiumum_count
+  runners_maximum_count           = var.runners_maximum_count
 
   lambda_zip                = var.runners_lambda_zip
   lambda_timeout_scale_up   = var.runners_scale_up_lambda_timeout

--- a/modules/runners/README.md
+++ b/modules/runners/README.md
@@ -82,7 +82,7 @@ No requirements.
 | role\_permissions\_boundary | Permissions boundary that will be added to the created role for the lambda. | `string` | `null` | no |
 | runner\_as\_root | Run the action runner under the root user. | `bool` | `false` | no |
 | runner\_extra\_labels | Extra labels for the runners (GitHub). Separate each label by a comma | `string` | `""` | no |
-| runners\_maxiumum\_count | The maxiumum number of runners tha will be created. | `number` | `3` | no |
+| runners\_maximum\_count | The maximum number of runners tha will be created. | `number` | `3` | no |
 | s3\_bucket\_runner\_binaries | n/a | <pre>object({<br>    arn = string<br>  })</pre> | n/a | yes |
 | s3\_location\_runner\_binaries | S3 location of runner distribution. | `string` | n/a | yes |
 | scale\_down\_schedule\_expression | Scheduler expression to check every x for scale down. | `string` | `"cron(*/5 * * * ? *)"` | no |

--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "scale_up" {
       KMS_KEY_ID                  = var.encryption.kms_key_id
       ENABLE_ORGANIZATION_RUNNERS = var.enable_organization_runners
       RUNNER_EXTRA_LABELS         = var.runner_extra_labels
-      RUNNERS_MAXIMUM_COUNT       = var.runners_maxiumum_count
+      RUNNERS_MAXIMUM_COUNT       = var.runners_maximum_count
       GITHUB_APP_KEY_BASE64       = local.github_app_key_base64
       GITHUB_APP_ID               = var.github_app.id
       GITHUB_APP_CLIENT_ID        = var.github_app.client_id

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -174,8 +174,8 @@ variable "runner_as_root" {
   default     = false
 }
 
-variable "runners_maxiumum_count" {
-  description = "The maxiumum number of runners tha will be created."
+variable "runners_maximum_count" {
+  description = "The maximum number of runners tha will be created."
   type        = number
   default     = 3
 }

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -175,7 +175,7 @@ variable "runner_as_root" {
 }
 
 variable "runners_maximum_count" {
-  description = "The maximum number of runners tha will be created."
+  description = "The maximum number of runners that will be created."
   type        = number
   default     = 3
 }

--- a/variables.tf
+++ b/variables.tf
@@ -132,8 +132,8 @@ variable "runner_as_root" {
   default     = false
 }
 
-variable "runners_maxiumum_count" {
-  description = "The maxiumum number of runners tha will be created."
+variable "runners_maximum_count" {
+  description = "The maximum number of runners tha will be created."
   type        = number
   default     = 3
 }

--- a/variables.tf
+++ b/variables.tf
@@ -133,7 +133,7 @@ variable "runner_as_root" {
 }
 
 variable "runners_maximum_count" {
-  description = "The maximum number of runners tha will be created."
+  description = "The maximum number of runners that will be created."
   type        = number
   default     = 3
 }


### PR DESCRIPTION
I'm providing this PR to fix https://github.com/philips-labs/terraform-aws-github-runner/issues/51. It just fixes a typo in a variable name. It also fixes the descriptions of two other variables.

### Description of the Change

- Renamed variable 'runners_maxiumum_count' as 'runners_maximum_count'
- Fixed descriptions of runners_scale_down and runners_scale_up variables

### Release Notes

- Renamed variable 'runners_maxiumum_count' as 'runners_maximum_count'. 
- Fixed descriptions of runners_scale_down and runners_scale_up variables
