### PR TITLE
RFC: allow more easily customizing the runner user data to allow non Amazon Linux AMIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| ami\_filter | List of maps used to create the AMI filter for the action runner AMI. | `map(list(string))` | <pre>{<br>  "name": [<br>    "amzn2-ami-hvm-2.*-x86_64-ebs"<br>  ]<br>}</pre> | no |
+| ami\_owners | The list of owners used to select the AMI of action runner instances. | `list(string)` | <pre>[<br>  "amazon"<br>]</pre> | no |
 | aws\_region | AWS region. | `string` | n/a | yes |
 | enable\_organization\_runners | n/a | `bool` | n/a | yes |
 | encrypt\_secrets | Encrypt secret variables for lambda's such as secrets and private keys. | `bool` | `true` | no |
@@ -251,10 +253,11 @@ No requirements.
 | minimum\_running\_time\_in\_minutes | The time an ec2 action runner should be running at minimum before terminated if non busy. | `number` | `5` | no |
 | role\_path | The path that will be added to role path for created roles, if not set the environment name will be used. | `string` | `null` | no |
 | role\_permissions\_boundary | Permissions boundary that will be added to the created roles. | `string` | `null` | no |
-| runner\_as\_root | Run the action runner under the root user. | `bool` | `false` | no |
 | runner\_binaries\_syncer\_lambda\_timeout | Time out of the binaries sync lambda in seconds. | `number` | `300` | no |
 | runner\_binaries\_syncer\_lambda\_zip | File location of the binaries sync lambda zip file. | `string` | `null` | no |
 | runner\_extra\_labels | Extra labels for the runners (GitHub). Separate each label by a comma | `string` | `""` | no |
+| runner\_user | The user to run the action runner under when using the default provided user\_data (see var.runner\_user\_data). | `string` | `"ec2-user"` | no |
+| runner\_user\_data | User data to provide when launching the instance. Defaults to a user data for setting up the runner on Amazon Linux. | `string` | `null` | no |
 | runners\_lambda\_zip | File location of the lambda zip file for scaling runners. | `string` | `null` | no |
 | runners\_maximum\_count | The maximum number of runners that will be created. | `number` | `3` | no |
 | runners\_scale\_down\_lambda\_timeout | Time out for the scale up lambda in seconds. | `number` | `60` | no |
@@ -262,8 +265,8 @@ No requirements.
 | scale\_down\_schedule\_expression | Scheduler expression to check every x for scale down. | `string` | `"cron(*/5 * * * ? *)"` | no |
 | subnet\_ids | List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_id`. | `list(string)` | n/a | yes |
 | tags | Map of tags that will be added to created resources. By default resources will be tagged with name and environment. | `map(string)` | `{}` | no |
-| userdata\_post\_install | Script to be ran after the GitHub Actions runner is installed on the EC2 instances | `string` | `""` | no |
-| userdata\_pre\_install | Script to be ran before the GitHub Actions runner is installed on the EC2 instances | `string` | `""` | no |
+| userdata\_post\_install | Script to be ran after the GitHub Actions runner is installed on the EC2 instances. Only used if the default var.runner\_user\_data is not set. | `string` | `""` | no |
+| userdata\_pre\_install | Script to be ran before the GitHub Actions runner is installed on the EC2 instances. Only used if the default var.runner\_user\_data is not set. | `string` | `""` | no |
 | vpc\_id | The VPC for security groups of the action runners. | `string` | n/a | yes |
 | webhook\_lambda\_timeout | Time out of the webhook lambda in seconds. | `number` | `10` | no |
 | webhook\_lambda\_zip | File location of the webhook lambda zip file. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,8 @@ module "runners" {
   scale_down_schedule_expression  = var.scale_down_schedule_expression
   minimum_running_time_in_minutes = var.minimum_running_time_in_minutes
   runner_extra_labels             = var.runner_extra_labels
-  runner_as_root                  = var.runner_as_root
+  runner_user_data                = var.runner_user_data
+  runner_user                     = var.runner_user
   runners_maximum_count           = var.runners_maximum_count
 
   lambda_zip                = var.runners_lambda_zip

--- a/modules/runners/README.md
+++ b/modules/runners/README.md
@@ -57,6 +57,7 @@ No requirements.
 | Name | Version |
 |------|---------|
 | aws | n/a |
+| template | n/a |
 
 ## Inputs
 
@@ -80,8 +81,9 @@ No requirements.
 | overrides | This maps provides the possibility to override some defaults. The following attributes are supported: `name_sg` overwrite the `Name` tag for all security groups created by this module. `name_runner_agent_instance` override the `Name` tag for the ec2 instance defined in the auto launch configuration. `name_docker_machine_runners` override the `Name` tag spot instances created by the runner agent. | `map(string)` | <pre>{<br>  "name_runner": "",<br>  "name_sg": ""<br>}</pre> | no |
 | role\_path | The path that will be added to the role, if not set the environment name will be used. | `string` | `null` | no |
 | role\_permissions\_boundary | Permissions boundary that will be added to the created role for the lambda. | `string` | `null` | no |
-| runner\_as\_root | Run the action runner under the root user. | `bool` | `false` | no |
 | runner\_extra\_labels | Extra labels for the runners (GitHub). Separate each label by a comma | `string` | `""` | no |
+| runner\_user | The user to run the action runner under when using the default provided user\_data (see var.runner\_user\_data). | `string` | `"ec2-user"` | no |
+| runner\_user\_data | User data to provide when launching the instance. Defaults to a user data for setting up the runner on Amazon Linux. | `string` | n/a | yes |
 | runners\_maximum\_count | The maximum number of runners that will be created. | `number` | `3` | no |
 | s3\_bucket\_runner\_binaries | n/a | <pre>object({<br>    arn = string<br>  })</pre> | n/a | yes |
 | s3\_location\_runner\_binaries | S3 location of runner distribution. | `string` | n/a | yes |
@@ -89,8 +91,8 @@ No requirements.
 | sqs\_build\_queue | SQS queue to consume accepted build events. | <pre>object({<br>    arn = string<br>  })</pre> | n/a | yes |
 | subnet\_ids | List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_id`. | `list(string)` | n/a | yes |
 | tags | Map of tags that will be added to created resources. By default resources will be tagged with name and environment. | `map(string)` | `{}` | no |
-| userdata\_post\_install | User-data script snippet to insert after GitHub acton runner install | `string` | `""` | no |
-| userdata\_pre\_install | User-data script snippet to insert before GitHub acton runner install | `string` | `""` | no |
+| userdata\_post\_install | Script to be ran after the GitHub Actions runner is installed on the EC2 instances. Only used if the default var.runner\_user\_data is not set. | `string` | `""` | no |
+| userdata\_pre\_install | Script to be ran before the GitHub Actions runner is installed on the EC2 instances. Only used if the default var.runner\_user\_data is not set. | `string` | `""` | no |
 | vpc\_id | The VPC for the security groups. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/runners/templates/user-data.sh
+++ b/modules/runners/templates/user-data.sh
@@ -35,7 +35,7 @@ export RUNNER_ALLOW_RUNASROOT=1
 ./config.sh --unattended --name $INSTANCE_ID --work "_work" $CONFIG
 
 chown -R ec2-user:ec2-user .
-./svc.sh install ${service_user}
+./svc.sh install ${runner_user}
 
 ${post_install}
 

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -79,13 +79,13 @@ variable "ami_owners" {
 }
 
 variable "userdata_pre_install" {
-  description = "User-data script snippet to insert before GitHub acton runner install"
+  description = "Script to be ran before the GitHub Actions runner is installed on the EC2 instances. Only used if the default var.runner_user_data is not set."
   type        = string
   default     = ""
 }
 
 variable "userdata_post_install" {
-  description = "User-data script snippet to insert after GitHub acton runner install"
+  description = "Script to be ran after the GitHub Actions runner is installed on the EC2 instances. Only used if the default var.runner_user_data is not set."
   type        = string
   default     = ""
 }
@@ -165,10 +165,15 @@ variable "instance_profile_path" {
   default     = null
 }
 
-variable "runner_as_root" {
-  description = "Run the action runner under the root user."
-  type        = bool
-  default     = false
+variable "runner_user_data" {
+  description = "User data to provide when launching the instance. Defaults to a user data for setting up the runner on Amazon Linux."
+  type        = string
+}
+
+variable "runner_user" {
+  description = "The user to run the action runner under when using the default provided user_data (see var.runner_user_data)."
+  type        = string
+  default     = "ec2-user"
 }
 
 variable "runners_maximum_count" {

--- a/variables.tf
+++ b/variables.tf
@@ -123,10 +123,31 @@ variable "instance_type" {
   default     = "m5.large"
 }
 
-variable "runner_as_root" {
-  description = "Run the action runner under the root user."
-  type        = bool
-  default     = false
+variable "ami_filter" {
+  description = "List of maps used to create the AMI filter for the action runner AMI."
+  type        = map(list(string))
+
+  default = {
+    name = ["amzn2-ami-hvm-2.*-x86_64-ebs"]
+  }
+}
+
+variable "ami_owners" {
+  description = "The list of owners used to select the AMI of action runner instances."
+  type        = list(string)
+  default     = ["amazon"]
+}
+
+variable "runner_user_data" {
+  description = "User data to provide when launching the instance. Defaults to a user data for setting up the runner on Amazon Linux."
+  type        = string
+  default     = null
+}
+
+variable "runner_user" {
+  description = "The user to run the action runner under when using the default provided user_data (see var.runner_user_data)."
+  type        = string
+  default     = "ec2-user"
 }
 
 variable "runners_maximum_count" {
@@ -152,13 +173,15 @@ variable "kms_key_id" {
   type        = string
   default     = null
 }
+
 variable "userdata_pre_install" {
+  description = "Script to be ran before the GitHub Actions runner is installed on the EC2 instances. Only used if the default var.runner_user_data is not set."
   type        = string
   default     = ""
-  description = "Script to be ran before the GitHub Actions runner is installed on the EC2 instances"
 }
+
 variable "userdata_post_install" {
+  description = "Script to be ran after the GitHub Actions runner is installed on the EC2 instances. Only used if the default var.runner_user_data is not set."
   type        = string
   default     = ""
-  description = "Script to be ran after the GitHub Actions runner is installed on the EC2 instances"
 }


### PR DESCRIPTION
### Description of the Change

Hi there,

I noticed that this module is quite heavily coupled to amazon linux: the hard coded non configurable user data and runner user (`ec2-user`).

I want to run my runners on a custom AMI based on ubuntu, so I need to be able to provide custom user data and user.

I've made a very quick change here to gather some feedback on if this approach would be acceptable or not.

I have maintained the current defaults of this module making it usable on Amazon linux, but made it more configurable for my use case.

Description of changes:

1. replace `var.runner_as_root` with `var.runner_user`, for maximum flexibility.
1. add `var.runner_user_data`, maintaining current default, for maximum flexibility.
1. ~~remove `var.userdata_pre_install` and `var.userdata_post_install` as they don't really provide much flexibility and do not solve my use case. Prefer `var.runner_user_data`.~~

TODO: 

- [ ] Please can you add an extra example, based on default where you provide the setup with for example  ubunut, I assume you have all the code all ready.
- [ ] If find a good spot in the readme feel free to add a note about this option, the feature make really difference.

Thanks for the consideration!

### Alternate Designs

Not sure. Can't yet think of anything.

### Possible Drawbacks

None?

### Verification Process

Minimal at the moment  - this is an RFC rather than a finished PR.

### Release Notes

TODO