### PR TITLE
Fix the build script not entering all the module directories

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-lambdaSrcDirs=("modules/runner-binaries-syncer/lambdas/runner-binaries-syncer" "modules/runners/lambdas/scale-runners" "modules/webhook/lambdas/webhook")
-repoRoot=$(dirname "${BASH_SOURCE[0]}")/..
+lambdaSrcDirs=("modules/runner-binaries-syncer/lambdas/runner-binaries-syncer" "modules/runners/lambdas/runners" "modules/webhook/lambdas/webhook")
+repoRoot=$(dirname $(dirname $(realpath ${BASH_SOURCE[0]})))
 
 for lambdaDir in ${lambdaSrcDirs[@]}; do
-    cd $repoRoot/${lambdaDir}
+    cd "$repoRoot/${lambdaDir}"
     docker build -t lambda -f ../../../../.ci/Dockerfile .
     docker create --name lambda lambda
     zipName=$(basename "$PWD")


### PR DESCRIPTION
* Running `.ci/build.sh` fails after the first module run as the root directory is a relative path. Fixed by making the root directory an absolute path.
* Fixed incorrect runners lambda path.