### PR TITLE
Smartlyio/fetch latest runner prerelease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ terraform import module.runners.module.runners.aws_cloudwatch_log_group.scale_up
 terraform import module.runners.module.runners.aws_cloudwatch_log_group.scale_down "/aws/lambda/default-scale-down"
 terraform import module.runners.module.webhook.aws_cloudwatch_log_group.webhook "/aws/lambda/default-webhook"
 ```
+- fix: Syncer will now sync the latest github actions runner pre-release, preventing any auto-updating on startup
 
 ## [0.4.0] - 2020-08-10
 

--- a/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer/src/syncer/handler.test.ts
+++ b/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer/src/syncer/handler.test.ts
@@ -6,7 +6,7 @@ import latestReleasesNoArm64 from '../../test/resources/github-latest-releases-n
 
 const mockOctokit = {
   repos: {
-    getLatestRelease: jest.fn(),
+    listReleases: jest.fn(),
   },
 };
 jest.mock('@octokit/rest', () => ({
@@ -32,8 +32,8 @@ describe('Synchronize action distribution.', () => {
     process.env.S3_BUCKET_NAME = bucketName;
     process.env.S3_OBJECT_KEY = bucketObjectKey;
 
-    mockOctokit.repos.getLatestRelease.mockImplementation(() => ({
-      data: latestReleases.data,
+    mockOctokit.repos.listReleases.mockImplementation(() => ({
+      data: [latestReleases.data],
     }));
   });
 
@@ -47,7 +47,7 @@ describe('Synchronize action distribution.', () => {
     });
 
     await handle();
-    expect(mockOctokit.repos.getLatestRelease).toBeCalledTimes(1);
+    expect(mockOctokit.repos.listReleases).toBeCalledTimes(1);
     expect(mockS3.getObjectTagging).toBeCalledWith({
       Bucket: bucketName,
       Key: bucketObjectKey,
@@ -65,7 +65,7 @@ describe('Synchronize action distribution.', () => {
     });
 
     await handle();
-    expect(mockOctokit.repos.getLatestRelease).toBeCalledTimes(1);
+    expect(mockOctokit.repos.listReleases).toBeCalledTimes(1);
     expect(mockS3.getObjectTagging).toBeCalledWith({
       Bucket: bucketName,
       Key: bucketObjectKey,
@@ -83,7 +83,7 @@ describe('Synchronize action distribution.', () => {
     });
 
     await handle();
-    expect(mockOctokit.repos.getLatestRelease).toBeCalledTimes(1);
+    expect(mockOctokit.repos.listReleases).toBeCalledTimes(1);
     expect(mockS3.getObjectTagging).toBeCalledWith({
       Bucket: bucketName,
       Key: bucketObjectKey,
@@ -101,7 +101,7 @@ describe('Synchronize action distribution.', () => {
     });
 
     await handle();
-    expect(mockOctokit.repos.getLatestRelease).toBeCalledTimes(1);
+    expect(mockOctokit.repos.listReleases).toBeCalledTimes(1);
     expect(mockS3.getObjectTagging).toBeCalledWith({
       Bucket: bucketName,
       Key: bucketObjectKey,
@@ -118,16 +118,16 @@ describe('No release assets found.', () => {
   });
 
   it('Empty list of assets.', async () => {
-    mockOctokit.repos.getLatestRelease.mockImplementation(() => ({
-      data: latestReleasesEmpty.data,
+    mockOctokit.repos.listReleases.mockImplementation(() => ({
+      data: [latestReleasesEmpty.data],
     }));
 
     await expect(handle()).rejects.toThrow(errorMessage);
   });
 
   it('No linux x64 asset.', async () => {
-    mockOctokit.repos.getLatestRelease.mockImplementation(() => ({
-      data: latestReleasesNoLinux.data,
+    mockOctokit.repos.listReleases.mockImplementation(() => ({
+      data: [latestReleasesNoLinux.data],
     }));
 
     await expect(handle()).rejects.toThrow(errorMessage);
@@ -162,8 +162,8 @@ describe('Synchronize action distribution for arm64.', () => {
  });
 
  it('No linux arm64 asset.', async () => {
-  mockOctokit.repos.getLatestRelease.mockImplementation(() => ({
-    data: latestReleasesNoArm64.data,
+  mockOctokit.repos.listReleases.mockImplementation(() => ({
+    data: [latestReleasesNoArm64.data],
   }));
 
   await expect(handle()).rejects.toThrow(errorMessage);

--- a/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer/src/syncer/handler.ts
+++ b/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer/src/syncer/handler.ts
@@ -33,11 +33,15 @@ interface ReleaseAsset {
 
 async function getLinuxReleaseAsset(runnerArch = 'x64'): Promise<ReleaseAsset | undefined> {
   const githubClient = new Octokit();
-  const assets = await githubClient.repos.getLatestRelease({
+  const assetsList = await githubClient.repos.listReleases({
     owner: 'actions',
     repo: 'runner',
   });
-  const linuxAssets = assets.data.assets?.filter((a) => a.name?.includes(`actions-runner-linux-${runnerArch}-`));
+  if (assetsList.data?.length === 0) {
+    return undefined;
+  }
+  const assets = assetsList.data[0];
+  const linuxAssets = assets.assets?.filter((a) => a.name?.includes(`actions-runner-linux-${runnerArch}-`));
 
   return linuxAssets?.length === 1
     ? { name: linuxAssets[0].name, downloadUrl: linuxAssets[0].browser_download_url }


### PR DESCRIPTION

### Identify the Bug

#74: Runners don't pick up the first job that triggered scale-up due to updating to a pre-release of github actions runner.

### Description of the Change

This change causes the runner sync lambda to pre-cache the latest pre-release of the github actions runner to prevent auto-update on start.

It achieves this by listing all releases, which includes pre-releases, and selecting the first release, which should be the most recent.

### Alternate Designs

N/A

### Possible Drawbacks

It is not explicitly documented that releases are provided in the order expected by this change. If the order provided by github changes, this will fail unless all pages of releases are retrieved and sorted by the client.

### Verification Process

- The unit tests are updated to match the expected API.
- The code included here has been running live for about a week without any issues.

### Release Notes

- syncer will now sync the latest github actions runner pre-release, preventing any auto-updating on startup