### PR TITLE
Provide hooks for using alternate runner os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ terraform import module.runners.module.runners.aws_cloudwatch_log_group.scale_up
 terraform import module.runners.module.runners.aws_cloudwatch_log_group.scale_down "/aws/lambda/default-scale-down"
 terraform import module.runners.module.webhook.aws_cloudwatch_log_group.webhook "/aws/lambda/default-webhook"
 ```
+- feat: Expose ami-filters and user-data template file location to users to allow use of custom AMIs
 
 - feat: Added option to binaries syncer to upgrade to pre-releases, preventing any auto-updating on startup. Option `runner_allow_prerelease_binaries` is disabled by default. (#141, #165) @sjagoe
 

--- a/examples/ubuntu/README.md
+++ b/examples/ubuntu/README.md
@@ -1,0 +1,21 @@
+# Action runners deployment ubuntu example
+
+This modules shows how to create GitHub action runners using an Ubuntu AMI. Lambda release will be downloaded from GitHub.
+
+## Usages
+
+Steps for the full setup, such as creating a GitHub app can be found in the root module's [README](../../README.md). First download the Lambda releases from GitHub. Alternatively you can build the lambdas locally with Node or Docker, there is a simple build script in `<root>/.ci/build.sh`. In the `main.tf` you can simple remove the location of the lambda zip files, the default location will work in this case.
+
+```bash
+cd lambdas-download
+terraform init
+terraform apply
+cd ..
+```
+
+Before running Terraform, ensure the GitHub app is configured.
+
+```bash
+terraform init
+terraform apply
+```

--- a/examples/ubuntu/lambdas-download/main.tf
+++ b/examples/ubuntu/lambdas-download/main.tf
@@ -1,0 +1,21 @@
+module "lambdas" {
+  source = "../../../modules/download-lambda"
+  lambdas = [
+    {
+      name = "webhook"
+      tag  = "v0.5.0"
+    },
+    {
+      name = "runners"
+      tag  = "v0.5.0"
+    },
+    {
+      name = "runner-binaries-syncer"
+      tag  = "v0.5.0"
+    }
+  ]
+}
+
+output "files" {
+  value = module.lambdas.files
+}

--- a/examples/ubuntu/main.tf
+++ b/examples/ubuntu/main.tf
@@ -1,5 +1,5 @@
 locals {
-  environment = "default"
+  environment = "ubuntu"
   aws_region  = "eu-west-1"
 }
 
@@ -27,9 +27,9 @@ module "runners" {
     webhook_secret = random_password.random.result
   }
 
-  # webhook_lambda_zip                = "lambdas-download/webhook.zip"
-  # runner_binaries_syncer_lambda_zip = "lambdas-download/runner-binaries-syncer.zip"
-  # runners_lambda_zip                = "lambdas-download/runners.zip"
+  webhook_lambda_zip                = "lambdas-download/webhook.zip"
+  runner_binaries_syncer_lambda_zip = "lambdas-download/runner-binaries-syncer.zip"
+  runners_lambda_zip                = "lambdas-download/runners.zip"
   enable_organization_runners = false
   runner_extra_labels         = "ubuntu,example"
 

--- a/examples/ubuntu/main.tf
+++ b/examples/ubuntu/main.tf
@@ -30,6 +30,7 @@ module "runners" {
   webhook_lambda_zip                = "lambdas-download/webhook.zip"
   runner_binaries_syncer_lambda_zip = "lambdas-download/runner-binaries-syncer.zip"
   runners_lambda_zip                = "lambdas-download/runners.zip"
+
   enable_organization_runners = false
   runner_extra_labels         = "ubuntu,example"
 

--- a/examples/ubuntu/main.tf
+++ b/examples/ubuntu/main.tf
@@ -37,10 +37,12 @@ module "runners" {
   enable_ssm_on_runners = true
 
   userdata_template = "./templates/user-data.sh"
-  ami_owners = ["099720109477"]  # Canonical's Amazon account ID
+  ami_owners        = ["099720109477"] # Canonical's Amazon account ID
+
   ami_filter = {
     name = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
   }
+
   block_device_mappings = {
     # Set the block device name for Ubuntu root device
     device_name = "/dev/sda1"

--- a/examples/ubuntu/main.tf
+++ b/examples/ubuntu/main.tf
@@ -1,0 +1,58 @@
+locals {
+  environment = "default"
+  aws_region  = "eu-west-1"
+}
+
+resource "random_password" "random" {
+  length = 28
+}
+
+module "runners" {
+  source = "../../"
+
+  aws_region = local.aws_region
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  environment = local.environment
+  tags = {
+    Project = "ProjectX"
+  }
+
+  github_app = {
+    key_base64     = var.github_app_key_base64
+    id             = var.github_app_id
+    client_id      = var.github_app_client_id
+    client_secret  = var.github_app_client_secret
+    webhook_secret = random_password.random.result
+  }
+
+  # webhook_lambda_zip                = "lambdas-download/webhook.zip"
+  # runner_binaries_syncer_lambda_zip = "lambdas-download/runner-binaries-syncer.zip"
+  # runners_lambda_zip                = "lambdas-download/runners.zip"
+  enable_organization_runners = false
+  runner_extra_labels         = "ubuntu,example"
+
+  # enable access to the runners via SSM
+  enable_ssm_on_runners = true
+
+  userdata_template = "./templates/user-data.sh"
+  ami_owners = ["099720109477"]  # Canonical's Amazon account ID
+  ami_filter = {
+    name = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+  block_device_mappings = {
+    # Set the block device name for Ubuntu root device
+    device_name = "/dev/sda1"
+  }
+
+  # Uncommet idle config to have idle runners from 9 to 5 in time zone Amsterdam
+  # idle_config = [{
+  #   cron      = "* * 9-17 * * *"
+  #   timeZone  = "Europe/Amsterdam"
+  #   idleCount = 1
+  # }]
+
+  # disable KMS and encryption
+  # encrypt_secrets = false
+}

--- a/examples/ubuntu/outputs.tf
+++ b/examples/ubuntu/outputs.tf
@@ -1,0 +1,12 @@
+output "runners" {
+  value = {
+    lambda_syncer_name = module.runners.binaries_syncer.lambda.function_name
+  }
+}
+
+output "webhook" {
+  value = {
+    secret   = random_password.random.result
+    endpoint = module.runners.webhook.endpoint
+  }
+}

--- a/examples/ubuntu/providers.tf
+++ b/examples/ubuntu/providers.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = local.aws_region
+  version = "3.0"
+}

--- a/examples/ubuntu/templates/user-data.sh
+++ b/examples/ubuntu/templates/user-data.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
+
+# Install AWS CLI
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y awscli jq
+
+# Install runner
+cd /home/ubuntu
+mkdir actions-runner && cd actions-runner
+
+aws s3 cp ${s3_location_runner_distribution} actions-runner.tar.gz
+tar xzf ./actions-runner.tar.gz
+rm -rf actions-runner.tar.gz
+
+INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+
+echo wait for configuration
+while [[ $(aws ssm get-parameters --names ${environment}-$INSTANCE_ID --with-decryption --region $REGION | jq -r ".Parameters | .[0] | .Value") == null ]]; do
+    echo Waiting for configuration ...
+    sleep 1
+done
+CONFIG=$(aws ssm get-parameters --names ${environment}-$INSTANCE_ID --with-decryption --region $REGION | jq -r ".Parameters | .[0] | .Value")
+aws ssm delete-parameter --name ${environment}-$INSTANCE_ID --region $REGION
+
+export RUNNER_ALLOW_RUNASROOT=1
+
+sudo -u ubuntu mkdir /home/ubuntu/work
+
+./bin/installdependencies.sh
+./config.sh --unattended --name $INSTANCE_ID --work "/home/ubuntu/work" $CONFIG
+
+chown -R ubuntu:ubuntu .
+./svc.sh install ubuntu
+
+./svc.sh start

--- a/examples/ubuntu/variables.tf
+++ b/examples/ubuntu/variables.tf
@@ -1,0 +1,8 @@
+
+variable "github_app_key_base64" {}
+
+variable "github_app_id" {}
+
+variable "github_app_client_id" {}
+
+variable "github_app_client_secret" {}

--- a/examples/ubuntu/vpc.tf
+++ b/examples/ubuntu/vpc.tf
@@ -1,0 +1,7 @@
+module "vpc" {
+  source = "git::https://github.com/philips-software/terraform-aws-vpc.git?ref=2.1.0"
+
+  environment                = local.environment
+  aws_region                 = local.aws_region
+  create_private_hosted_zone = false
+}

--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,7 @@ module "runners" {
   s3_location_runner_binaries = local.s3_action_runner_url
 
   instance_type = var.instance_type
+  block_device_mappings = var.block_device_mappings
 
   runner_architecture = local.runner_architecture
   ami_filter          = local.runner_architecture == "arm64" ? { name = ["amzn2-ami-hvm-2*-arm64-gp2"] } : { name = ["amzn2-ami-hvm-2.*-x86_64-ebs"] }

--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,7 @@ module "runners" {
   role_path                 = var.role_path
   role_permissions_boundary = var.role_permissions_boundary
 
+  userdata_template     = var.userdata_template
   userdata_pre_install  = var.userdata_pre_install
   userdata_post_install = var.userdata_post_install
 }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   s3_action_runner_url = "s3://${module.runner_binaries.bucket.id}/${module.runner_binaries.runner_distribution_object_key}"
   runner_architecture  = substr(var.instance_type, 0, 2) == "a1" || substr(var.instance_type, 1, 2) == "6g" ? "arm64" : "x64"
 
-  ami_filter        = length(var.ami_filter) > 0 ? var.ami_filter : local.runner_architecture == "arm64" ? { name = ["amzn2-ami-hvm-2*-arm64-gp2"] } : { name = ["amzn2-ami-hvm-2.*-x86_64-ebs"] }
+  ami_filter = length(var.ami_filter) > 0 ? var.ami_filter : local.runner_architecture == "arm64" ? { name = ["amzn2-ami-hvm-2*-arm64-gp2"] } : { name = ["amzn2-ami-hvm-2.*-x86_64-ebs"] }
 }
 
 resource "random_string" "random" {

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,9 @@ locals {
 
   s3_action_runner_url = "s3://${module.runner_binaries.bucket.id}/${module.runner_binaries.runner_distribution_object_key}"
   runner_architecture  = substr(var.instance_type, 0, 2) == "a1" || substr(var.instance_type, 1, 2) == "6g" ? "arm64" : "x64"
+
+  ami_filters_exist = length(var.ami_filter) > 0
+  ami_filter = local.ami_filters_exist ? var.ami_filter : local.runner_architecture == "arm64" ? { name = ["amzn2-ami-hvm-2*-arm64-gp2"] } : { name = ["amzn2-ami-hvm-2.*-x86_64-ebs"] }
 }
 
 resource "random_string" "random" {
@@ -66,7 +69,8 @@ module "runners" {
   block_device_mappings = var.block_device_mappings
 
   runner_architecture = local.runner_architecture
-  ami_filter          = local.runner_architecture == "arm64" ? { name = ["amzn2-ami-hvm-2*-arm64-gp2"] } : { name = ["amzn2-ami-hvm-2.*-x86_64-ebs"] }
+  ami_filter          = local.ami_filter
+  ami_owners          = var.ami_owners
 
   sqs_build_queue                 = aws_sqs_queue.queued_builds
   github_app                      = var.github_app

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,7 @@ locals {
   s3_action_runner_url = "s3://${module.runner_binaries.bucket.id}/${module.runner_binaries.runner_distribution_object_key}"
   runner_architecture  = substr(var.instance_type, 0, 2) == "a1" || substr(var.instance_type, 1, 2) == "6g" ? "arm64" : "x64"
 
-  ami_filters_exist = length(var.ami_filter) > 0
-  ami_filter        = local.ami_filters_exist ? var.ami_filter : local.runner_architecture == "arm64" ? { name = ["amzn2-ami-hvm-2*-arm64-gp2"] } : { name = ["amzn2-ami-hvm-2.*-x86_64-ebs"] }
+  ami_filter        = length(var.ami_filter) > 0 ? var.ami_filter : local.runner_architecture == "arm64" ? { name = ["amzn2-ami-hvm-2*-arm64-gp2"] } : { name = ["amzn2-ami-hvm-2.*-x86_64-ebs"] }
 }
 
 resource "random_string" "random" {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
   runner_architecture  = substr(var.instance_type, 0, 2) == "a1" || substr(var.instance_type, 1, 2) == "6g" ? "arm64" : "x64"
 
   ami_filters_exist = length(var.ami_filter) > 0
-  ami_filter = local.ami_filters_exist ? var.ami_filter : local.runner_architecture == "arm64" ? { name = ["amzn2-ami-hvm-2*-arm64-gp2"] } : { name = ["amzn2-ami-hvm-2.*-x86_64-ebs"] }
+  ami_filter        = local.ami_filters_exist ? var.ami_filter : local.runner_architecture == "arm64" ? { name = ["amzn2-ami-hvm-2*-arm64-gp2"] } : { name = ["amzn2-ami-hvm-2.*-x86_64-ebs"] }
 }
 
 resource "random_string" "random" {
@@ -65,7 +65,7 @@ module "runners" {
   s3_bucket_runner_binaries   = module.runner_binaries.bucket
   s3_location_runner_binaries = local.s3_action_runner_url
 
-  instance_type = var.instance_type
+  instance_type         = var.instance_type
   block_device_mappings = var.block_device_mappings
 
   runner_architecture = local.runner_architecture

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -14,6 +14,7 @@ locals {
   role_path             = var.role_path == null ? "/${var.environment}/" : var.role_path
   instance_profile_path = var.instance_profile_path == null ? "/${var.environment}/" : var.instance_profile_path
   lambda_zip            = var.lambda_zip == null ? "${path.module}/lambdas/runners/runners.zip" : var.lambda_zip
+  userdata_template     = var.userdata_template == null ? "${path.module}/templates/user-data.sh" : var.userdata_template
 }
 
 data "aws_ami" "runner" {
@@ -73,7 +74,7 @@ resource "aws_launch_template" "runner" {
     )
   }
 
-  user_data = base64encode(templatefile("${path.module}/templates/user-data.sh", {
+  user_data = base64encode(templatefile(local.userdata_template, {
     environment                     = var.environment
     pre_install                     = var.userdata_pre_install
     post_install                    = var.userdata_post_install

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -37,7 +37,7 @@ resource "aws_launch_template" "runner" {
   dynamic "block_device_mappings" {
     for_each = [var.block_device_mappings]
     content {
-      device_name = "/dev/xvda"
+      device_name = lookup(block_device_mappings.value, "device_name", "/dev/xvda")
 
       ebs {
         delete_on_termination = lookup(block_device_mappings.value, "delete_on_termination", true)

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -78,6 +78,12 @@ variable "ami_owners" {
   default     = ["amazon"]
 }
 
+variable "userdata_template" {
+  description = "Alternative user-data template, replacing the default template"
+  type        = string
+  default     = null
+}
+
 variable "userdata_pre_install" {
   description = "User-data script snippet to insert before GitHub acton runner install"
   type        = string

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -46,7 +46,7 @@ variable "s3_location_runner_binaries" {
 }
 
 variable "block_device_mappings" {
-  description = "The EC2 instance block device configuration. Takes the following keys: `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops`"
+  description = "The EC2 instance block device configuration. Takes the following keys: `device_name`, `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops`"
   type        = map(string)
   default     = {}
 }

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -79,7 +79,7 @@ variable "ami_owners" {
 }
 
 variable "userdata_template" {
-  description = "Alternative user-data template, replacing the default template"
+  description = "Alternative user-data template, replacing the default template. By providing your own user_data you have to take care of installing all required software, including the action runner. Variables userdata_pre/post_install are ignored."
   type        = string
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,12 @@ variable "kms_key_id" {
   default     = null
 }
 
+variable "userdata_template" {
+  description = "Alternative user-data template, replacing the default template"
+  type        = string
+  default     = null
+}
+
 variable "userdata_pre_install" {
   type        = string
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -204,3 +204,15 @@ variable "block_device_mappings" {
   type        = map(string)
   default     = {}
 }
+
+variable "ami_filter" {
+  description = "List of maps used to create the AMI filter for the action runner AMI."
+  type        = map(list(string))
+
+  default = {}
+}
+variable "ami_owners" {
+  description = "The list of owners used to select the AMI of action runner instances."
+  type        = list(string)
+  default     = ["amazon"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -198,3 +198,9 @@ variable "runner_allow_prerelease_binaries" {
   type        = bool
   default     = false
 }
+
+variable "block_device_mappings" {
+  description = "The EC2 instance block device configuration. Takes the following keys: `device_name`, `delete_on_termination`, `volume_type`, `volume_size`, `encrypted`, `iops`"
+  type        = map(string)
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -154,7 +154,7 @@ variable "kms_key_id" {
 }
 
 variable "userdata_template" {
-  description = "Alternative user-data template, replacing the default template"
+  description = "Alternative user-data template, replacing the default template. By providing your own user_data you have to take care of installing all required software, including the action runner. Variables userdata_pre/post_install are ignored."
   type        = string
   default     = null
 }
@@ -206,7 +206,7 @@ variable "block_device_mappings" {
 }
 
 variable "ami_filter" {
-  description = "List of maps used to create the AMI filter for the action runner AMI."
+  description = "List of maps used to create the AMI filter for the action runner AMI. By default amazon linux 2 is used."
   type        = map(list(string))
 
   default = {}


### PR DESCRIPTION


### Description of the Change

At Smartly.io, we want to use runners that largely reflect the hosted Ubuntu runners provided by Github, running on larger instances in AWS. We build internal AMIs based on similar packer configuration to https://github.com/actions/virtual-environments/blob/main/images/linux/ubuntu1804.json (and use some of the provisioning scripts from that repository).

This PR exposes the interfaces necessary to hook those custom AMIs into the terraform module, while maintaining the previous default behaviour of using Amazon linux images.

Example use:

```
module "github-runner" {
  # Using a local copy of the module
  source  = "./modules/github-runner"

  # ... All the usual configuration

  # Use custom AMI and user-data.sh template for bootstrapping
  userdata_template = "./templates/user-data.sh"
  ami_owners = ["self"]
  ami_filter = {
    name = ["myorg/github-actions-runner/ubuntu-18.04-*"]
  }

  # The device name here is required due to differences between Canonical ubuntu images and Amazon Linux
  block_device_mappings = {
    device_name = "/dev/sda1"
    # Use larger disks for more sustained IOPS
    volume_size = "500"
  }
}

```

### Alternate Designs

N/A This approach was taken to minimize the extent of changes to the terraform module

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

- The changes from this PR have been running live for at least a week
- A `terraform plan` without using the new variables outputs the expected changes to the infrastructure


### Release Notes

- feat: Expose ami-filters and user-data template file location to users to allow use of custom AMIs

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in the release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
