### PR TITLE
Add wildcard for log events in arbitrary streams

### DIFF
--- a/modules/runner-binaries-syncer/policies/lambda-cloudwatch.json
+++ b/modules/runner-binaries-syncer/policies/lambda-cloudwatch.json
@@ -4,7 +4,7 @@
     {
       "Effect": "Allow",
       "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
-      "Resource": "${log_group_arn}"
+      "Resource": "${log_group_arn}*"
     }
   ]
 }

--- a/modules/runners/policies/lambda-cloudwatch.json
+++ b/modules/runners/policies/lambda-cloudwatch.json
@@ -4,7 +4,7 @@
     {
       "Effect": "Allow",
       "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
-      "Resource": "${log_group_arn}"
+      "Resource": "${log_group_arn}*"
     }
   ]
 }

--- a/modules/webhook/policies/lambda-cloudwatch.json
+++ b/modules/webhook/policies/lambda-cloudwatch.json
@@ -4,7 +4,7 @@
     {
       "Effect": "Allow",
       "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
-      "Resource": "${log_group_arn}"
+      "Resource": "${log_group_arn}*"
     }
   ]
 }


### PR DESCRIPTION
Recently tried deploying v0.4.0 version of this module. None of the lambdas can log because the resource restriction stops log events from being created on log streams.