### PR TITLE
Use console.dir for higher logging depth

### DIFF
--- a/modules/runners/lambdas/runners/src/lambda.ts
+++ b/modules/runners/lambdas/runners/src/lambda.ts
@@ -3,7 +3,7 @@ import { scaleDown } from './scale-runners/scale-down';
 import { SQSEvent } from 'aws-lambda';
 
 module.exports.scaleUp = async (event: SQSEvent, context: any, callback: any) => {
-  console.log(event);
+  console.dir(event, { depth: 5 });
   try {
     for (const e of event.Records) {
       await scaleUp(e.eventSource, JSON.parse(e.body));


### PR DESCRIPTION
This should show full SQS message details rather than having `attributes` of a record show as `Object`