### PR TITLE
Only allow tagging and termination of runner instances

### DIFF
--- a/modules/runners/policies/lambda-scale-down.json
+++ b/modules/runners/policies/lambda-scale-down.json
@@ -5,11 +5,21 @@
       "Effect": "Allow",
       "Action": [
         "ec2:DescribeInstances*",
-        "ec2:DescribeTags",
-        "ec2:DeleteTags",
-        "ec2:TerminateInstances"
+        "ec2:DescribeTags"
       ],
       "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:TerminateInstances"
+      ],
+      "Resource": ["*"],
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/Application": "github-action-runner"
+        }
+      }
     }
   ]
 }

--- a/modules/runners/policies/lambda-scale-up.json
+++ b/modules/runners/policies/lambda-scale-up.json
@@ -6,10 +6,21 @@
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeTags",
-        "ec2:CreateTags",
         "ec2:RunInstances"
       ],
       "Resource": ["*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": ["*"],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction" : "RunInstances"
+        }
+      }
     },
     {
       "Effect": "Allow",


### PR DESCRIPTION
### Identify the Bug

Scaling lambda IAM roles permit tagging and termination of arbitrary EC2 instances, which is not desirable.

### Description of the Change

Harden scaling lambda IAM policies to ensure we can only tag and terminate _runner_ instances by:
- Scoping `ec2:CreateTags` to just instance creation
- Disallowing `ec2:DeleteTags` (seems to be unused anyways)
- Allowing `ec2:TerminateInstances` for only tagged runner instances

### Alternate Designs

N/A

### Possible Drawbacks

N/A

### Verification Process

This was tested by deploying the runner stack to an AWS account, and having the lambdas scale runners up and down, both of which _seem_ to have succeeded without errors (looking at lambda logs and EC2 instance states).

### Release Notes

-  Only allow tagging and termination of runner EC2 instances