### PR TITLE
expand options for sourcing lambda to include S3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,9 +40,12 @@ module "webhook" {
   sqs_build_queue           = aws_sqs_queue.queued_builds
   github_app_webhook_secret = var.github_app.webhook_secret
 
-  lambda_zip                = var.webhook_lambda_zip
-  lambda_timeout            = var.webhook_lambda_timeout
-  logging_retention_in_days = var.logging_retention_in_days
+  lambda_s3_bucket                 = var.lambda_s3_bucket
+  webhook_lambda_s3_key            = var.webhook_lambda_s3_key
+  webhook_lambda_s3_object_version = var.webhook_lambda_s3_object_version
+  lambda_zip                       = var.webhook_lambda_zip
+  lambda_timeout                   = var.webhook_lambda_timeout
+  logging_retention_in_days        = var.logging_retention_in_days
 
   role_path                 = var.role_path
   role_permissions_boundary = var.role_permissions_boundary
@@ -82,10 +85,13 @@ module "runners" {
   idle_config                     = var.idle_config
   enable_ssm_on_runners           = var.enable_ssm_on_runners
 
-  lambda_zip                = var.runners_lambda_zip
-  lambda_timeout_scale_up   = var.runners_scale_up_lambda_timeout
-  lambda_timeout_scale_down = var.runners_scale_down_lambda_timeout
-  logging_retention_in_days = var.logging_retention_in_days
+  lambda_s3_bucket                 = var.lambda_s3_bucket
+  runners_lambda_s3_key            = var.runners_lambda_s3_key
+  runners_lambda_s3_object_version = var.runners_lambda_s3_object_version
+  lambda_zip                       = var.runners_lambda_zip
+  lambda_timeout_scale_up          = var.runners_scale_up_lambda_timeout
+  lambda_timeout_scale_down        = var.runners_scale_down_lambda_timeout
+  logging_retention_in_days        = var.logging_retention_in_days
 
   instance_profile_path     = var.instance_profile_path
   role_path                 = var.role_path
@@ -108,9 +114,12 @@ module "runner_binaries" {
   runner_architecture              = substr(var.instance_type, 0, 2) == "a1" || substr(var.instance_type, 1, 2) == "6g" ? "arm64" : "x64"
   runner_allow_prerelease_binaries = var.runner_allow_prerelease_binaries
 
-  lambda_zip                = var.runner_binaries_syncer_lambda_zip
-  lambda_timeout            = var.runner_binaries_syncer_lambda_timeout
-  logging_retention_in_days = var.logging_retention_in_days
+  lambda_s3_bucket                = var.lambda_s3_bucket
+  syncer_lambda_s3_key            = var.syncer_lambda_s3_key
+  syncer_lambda_s3_object_version = var.syncer_lambda_s3_object_version
+  lambda_zip                      = var.runner_binaries_syncer_lambda_zip
+  lambda_timeout                  = var.runner_binaries_syncer_lambda_timeout
+  logging_retention_in_days       = var.logging_retention_in_days
 
   role_path                 = var.role_path
   role_permissions_boundary = var.role_permissions_boundary

--- a/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -4,13 +4,16 @@ locals {
 }
 
 resource "aws_lambda_function" "syncer" {
-  filename         = local.lambda_zip
-  source_code_hash = filebase64sha256(local.lambda_zip)
-  function_name    = "${var.environment}-syncer"
-  role             = aws_iam_role.syncer_lambda.arn
-  handler          = "index.handler"
-  runtime          = "nodejs12.x"
-  timeout          = var.lambda_timeout
+  s3_bucket         = var.lambda_s3_bucket != null ? var.lambda_s3_bucket : null
+  s3_key            = var.syncer_lambda_s3_key != null ? var.syncer_lambda_s3_key : null
+  s3_object_version = var.syncer_lambda_s3_object_version != null ? var.syncer_lambda_s3_object_version : null
+  filename          = var.lambda_s3_bucket == null ? local.lambda_zip : null
+  source_code_hash  = var.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
+  function_name     = "${var.environment}-syncer"
+  role              = aws_iam_role.syncer_lambda.arn
+  handler           = "index.handler"
+  runtime           = "nodejs12.x"
+  timeout           = var.lambda_timeout
 
   environment {
     variables = {

--- a/modules/runner-binaries-syncer/variables.tf
+++ b/modules/runner-binaries-syncer/variables.tf
@@ -66,3 +66,19 @@ variable "runner_allow_prerelease_binaries" {
   type        = bool
   default     = false
 }
+
+variable "lambda_s3_bucket" {
+  description = "S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly."
+  default = null
+}
+
+variable "syncer_lambda_s3_key" {
+  description = "S3 key for syncer lambda function. Required if using S3 bucket to specify lambdas."
+  default = null
+}
+
+variable "syncer_lambda_s3_object_version" {
+  description = "S3 object version for syncer lambda function. Useful if S3 versioning is enabled on source bucket."
+  default = null
+}
+

--- a/modules/runner-binaries-syncer/variables.tf
+++ b/modules/runner-binaries-syncer/variables.tf
@@ -69,16 +69,16 @@ variable "runner_allow_prerelease_binaries" {
 
 variable "lambda_s3_bucket" {
   description = "S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly."
-  default = null
+  default     = null
 }
 
 variable "syncer_lambda_s3_key" {
   description = "S3 key for syncer lambda function. Required if using S3 bucket to specify lambdas."
-  default = null
+  default     = null
 }
 
 variable "syncer_lambda_s3_object_version" {
   description = "S3 object version for syncer lambda function. Useful if S3 versioning is enabled on source bucket."
-  default = null
+  default     = null
 }
 

--- a/modules/runners/scale-down.tf
+++ b/modules/runners/scale-down.tf
@@ -13,14 +13,17 @@ resource "aws_kms_grant" "scale_down" {
 }
 
 resource "aws_lambda_function" "scale_down" {
-  filename         = local.lambda_zip
-  source_code_hash = filebase64sha256(local.lambda_zip)
-  function_name    = "${var.environment}-scale-down"
-  role             = aws_iam_role.scale_down.arn
-  handler          = "index.scaleDown"
-  runtime          = "nodejs12.x"
-  timeout          = var.lambda_timeout_scale_down
-  tags             = local.tags
+  s3_bucket         = var.lambda_s3_bucket != null ? var.lambda_s3_bucket : null
+  s3_key            = var.runners_lambda_s3_key != null ? var.runners_lambda_s3_key : null
+  s3_object_version = var.runners_lambda_s3_object_version != null ? var.runners_lambda_s3_object_version : null
+  filename          = var.lambda_s3_bucket == null ? local.lambda_zip : null
+  source_code_hash  = var.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
+  function_name     = "${var.environment}-scale-down"
+  role              = aws_iam_role.scale_down.arn
+  handler           = "index.scaleDown"
+  runtime           = "nodejs12.x"
+  timeout           = var.lambda_timeout_scale_down
+  tags              = local.tags
 
   environment {
     variables = {

--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -13,8 +13,11 @@ resource "aws_kms_grant" "scale_up" {
 }
 
 resource "aws_lambda_function" "scale_up" {
-  filename                       = local.lambda_zip
-  source_code_hash               = filebase64sha256(local.lambda_zip)
+  s3_bucket                      = var.lambda_s3_bucket != null ? var.lambda_s3_bucket : null
+  s3_key                         = var.runners_lambda_s3_key != null ? var.runners_lambda_s3_key : null
+  s3_object_version              = var.runners_lambda_s3_object_version != null ? var.runners_lambda_s3_object_version : null
+  filename                       = var.lambda_s3_bucket == null ? local.lambda_zip : null
+  source_code_hash               = var.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
   function_name                  = "${var.environment}-scale-up"
   role                           = aws_iam_role.scale_up.arn
   handler                        = "index.scaleUp"

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -217,3 +217,19 @@ variable "enable_ssm_on_runners" {
   description = "Enable to allow access the runner instances for debugging purposes via SSM. Note that this adds additional permissions to the runner instances."
   type        = bool
 }
+
+variable "lambda_s3_bucket" {
+  description = "S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly."
+  default = null
+}
+
+variable "runners_lambda_s3_key" {
+  description = "S3 key for runners lambda function. Required if using S3 bucket to specify lambdas."
+  default = null
+}
+
+variable "runners_lambda_s3_object_version" {
+  description = "S3 object version for runners lambda function. Useful if S3 versioning is enabled on source bucket."
+  default = null
+}
+

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -220,16 +220,16 @@ variable "enable_ssm_on_runners" {
 
 variable "lambda_s3_bucket" {
   description = "S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly."
-  default = null
+  default     = null
 }
 
 variable "runners_lambda_s3_key" {
   description = "S3 key for runners lambda function. Required if using S3 bucket to specify lambdas."
-  default = null
+  default     = null
 }
 
 variable "runners_lambda_s3_object_version" {
   description = "S3 object version for runners lambda function. Useful if S3 versioning is enabled on source bucket."
-  default = null
+  default     = null
 }
 

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -63,3 +63,19 @@ variable "logging_retention_in_days" {
   type        = number
   default     = 7
 }
+
+variable "lambda_s3_bucket" {
+  description = "S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly."
+  default = null
+}
+
+variable "webhook_lambda_s3_key" {
+  description = "S3 key for webhook lambda function. Required if using S3 bucket to specify lambdas."
+  default = null
+}
+
+variable "webhook_lambda_s3_object_version" {
+  description = "S3 object version for webhook lambda function. Useful if S3 versioning is enabled on source bucket."
+  default = null
+}
+

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -66,16 +66,16 @@ variable "logging_retention_in_days" {
 
 variable "lambda_s3_bucket" {
   description = "S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly."
-  default = null
+  default     = null
 }
 
 variable "webhook_lambda_s3_key" {
   description = "S3 key for webhook lambda function. Required if using S3 bucket to specify lambdas."
-  default = null
+  default     = null
 }
 
 variable "webhook_lambda_s3_object_version" {
   description = "S3 object version for webhook lambda function. Useful if S3 versioning is enabled on source bucket."
-  default = null
+  default     = null
 }
 

--- a/modules/webhook/webhook.tf
+++ b/modules/webhook/webhook.tf
@@ -27,13 +27,16 @@ resource "aws_kms_grant" "webhook" {
 }
 
 resource "aws_lambda_function" "webhook" {
-  filename         = local.lambda_zip
-  source_code_hash = filebase64sha256(local.lambda_zip)
-  function_name    = "${var.environment}-webhook"
-  role             = aws_iam_role.webhook_lambda.arn
-  handler          = "index.githubWebhook"
-  runtime          = "nodejs12.x"
-  timeout          = var.lambda_timeout
+  s3_bucket         = var.lambda_s3_bucket != null ? var.lambda_s3_bucket : null
+  s3_key            = var.webhook_lambda_s3_key != null ? var.webhook_lambda_s3_key : null
+  s3_object_version = var.webhook_lambda_s3_object_version != null ? var.webhook_lambda_s3_object_version : null
+  filename          = var.lambda_s3_bucket == null ? local.lambda_zip : null
+  source_code_hash  = var.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
+  function_name     = "${var.environment}-webhook"
+  role              = aws_iam_role.webhook_lambda.arn
+  handler           = "index.githubWebhook"
+  runtime           = "nodejs12.x"
+  timeout           = var.lambda_timeout
 
   environment {
     variables = {

--- a/variables.tf
+++ b/variables.tf
@@ -216,3 +216,38 @@ variable "ami_owners" {
   type        = list(string)
   default     = ["amazon"]
 }
+variable "lambda_s3_bucket" {
+  description = "S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly."
+  default = null
+}
+
+variable "syncer_lambda_s3_key" {
+  description = "S3 key for syncer lambda function. Required if using S3 bucket to specify lambdas."
+  default = null
+}
+
+variable "syncer_lambda_s3_object_version" {
+  description = "S3 object version for syncer lambda function. Useful if S3 versioning is enabled on source bucket."
+  default = null
+}
+
+variable "webhook_lambda_s3_key" {
+  description = "S3 key for webhook lambda function. Required if using S3 bucket to specify lambdas."
+  default = null
+}
+
+variable "webhook_lambda_s3_object_version" {
+  description = "S3 object version for webhook lambda function. Useful if S3 versioning is enabled on source bucket."
+  default = null
+}
+
+variable "runners_lambda_s3_key" {
+  description = "S3 key for runners lambda function. Required if using S3 bucket to specify lambdas."
+  default = null
+}
+
+variable "runners_lambda_s3_object_version" {
+  description = "S3 object version for runners lambda function. Useful if S3 versioning is enabled on source bucket."
+  default = null
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -218,36 +218,36 @@ variable "ami_owners" {
 }
 variable "lambda_s3_bucket" {
   description = "S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly."
-  default = null
+  default     = null
 }
 
 variable "syncer_lambda_s3_key" {
   description = "S3 key for syncer lambda function. Required if using S3 bucket to specify lambdas."
-  default = null
+  default     = null
 }
 
 variable "syncer_lambda_s3_object_version" {
   description = "S3 object version for syncer lambda function. Useful if S3 versioning is enabled on source bucket."
-  default = null
+  default     = null
 }
 
 variable "webhook_lambda_s3_key" {
   description = "S3 key for webhook lambda function. Required if using S3 bucket to specify lambdas."
-  default = null
+  default     = null
 }
 
 variable "webhook_lambda_s3_object_version" {
   description = "S3 object version for webhook lambda function. Useful if S3 versioning is enabled on source bucket."
-  default = null
+  default     = null
 }
 
 variable "runners_lambda_s3_key" {
   description = "S3 key for runners lambda function. Required if using S3 bucket to specify lambdas."
-  default = null
+  default     = null
 }
 
 variable "runners_lambda_s3_object_version" {
   description = "S3 object version for runners lambda function. Useful if S3 versioning is enabled on source bucket."
-  default = null
+  default     = null
 }
 


### PR DESCRIPTION
Submitting a small change to expand the options for sourcing the lambda functions to include S3. Using an S3 bucket would be an alternative to providing local files directly and providing the bucket itself would be up to the user.

We found that a change like this is personally better for our workflow and could be useful for others too. Thanks for the great work on this project!