### PR TITLE
Allow operator to pass in a list of managed IAM policy ARNs for the runner role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,6 +102,8 @@ module "runners" {
   userdata_post_install = var.userdata_post_install
 
   create_service_linked_role_spot = var.create_service_linked_role_spot
+
+  runner_iam_role_managed_policy_arns = var.runner_iam_role_managed_policy_arns
 }
 
 module "runner_binaries" {

--- a/modules/runners/policies-runner.tf
+++ b/modules/runners/policies-runner.tf
@@ -39,3 +39,9 @@ resource "aws_iam_role_policy" "dist_bucket" {
     }
   )
 }
+
+resource "aws_iam_role_policy_attachment" "managed_policies" {
+  count      = length(var.runner_iam_role_managed_policy_arns)
+  role       = aws_iam_role.runner.name
+  policy_arn = element(var.runner_iam_role_managed_policy_arns, count.index)
+}

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -240,7 +240,7 @@ variable "create_service_linked_role_spot" {
 }
 
 variable "runner_iam_role_managed_policy_arns" {
-  description = "Attach AWS or customer-managed IAM policies (ARNs) to the runner IAM role"
+  description = "Attach AWS or customer-managed IAM policies (by ARN) to the runner IAM role"
   type        = list(string)
   default     = []
 }

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -238,3 +238,9 @@ variable "create_service_linked_role_spot" {
   type        = bool
   default     = false
 }
+
+variable "runner_iam_role_managed_policy_arns" {
+  description = "Attach AWS or customer-managed IAM policies (ARNs) to the runner IAM role"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -256,3 +256,9 @@ variable "create_service_linked_role_spot" {
   type        = bool
   default     = false
 }
+
+variable "runner_iam_role_managed_policy_arns" {
+  description = "Attach AWS or customer-managed IAM policies (by ARN) to the runner IAM role"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
For https://github.com/philips-labs/terraform-aws-github-runner/issues/308. Policies can be managed outside of this stack, or within this stack like so:

```
resource "aws_iam_policy" "my_policy" {
  ...
}

module "runners" {
  ...
  runner_iam_role_managed_policy_arns = [
    aws_iam_policy.my_policy.arn,
  ]
}
```

Tested by running a `plan` on an existing stack, with and without the list of managed policies.