### PR TITLE
bugfix: Add policies for logging

### DIFF
--- a/modules/runners/logging.tf
+++ b/modules/runners/logging.tf
@@ -4,7 +4,7 @@ locals {
 
 resource "aws_ssm_parameter" "cloudwatch_agent_config_runner" {
   count = var.enable_cloudwatch_agent ? 1 : 0
-  name  = "${var.environment}-cloudwatch_agent_config_runner"
+  name  = "${var.environment}-runner"
   type  = "String"
   value = var.cloudwatch_config != null ? var.cloudwatch_config : templatefile("${path.module}/templates/cloudwatch_config.json", {
     logfiles = jsonencode(local.logfiles)
@@ -17,4 +17,15 @@ resource "aws_cloudwatch_log_group" "runners" {
   name              = "${var.environment}/runners"
   retention_in_days = var.logging_retention_in_days
   tags              = local.tags
+}
+
+resource "aws_iam_role_policy" "cloudwatch" {
+  count = var.enable_ssm_on_runners ? 1 : 0
+  name  = "CloudWatchLogginAndMetrics"
+  role  = aws_iam_role.runner.name
+  policy = templatefile("${path.module}/policies/instance-cloudwatch-policy.json",
+    {
+      ssm_parameter_arn = aws_ssm_parameter.cloudwatch_agent_config_runner[0].arn
+    }
+  )
 }

--- a/modules/runners/logging.tf
+++ b/modules/runners/logging.tf
@@ -4,7 +4,7 @@ locals {
 
 resource "aws_ssm_parameter" "cloudwatch_agent_config_runner" {
   count = var.enable_cloudwatch_agent ? 1 : 0
-  name  = "${var.environment}-runner"
+  name  = "${var.environment}-cloudwatch_agent_config_runner"
   type  = "String"
   value = var.cloudwatch_config != null ? var.cloudwatch_config : templatefile("${path.module}/templates/cloudwatch_config.json", {
     logfiles = jsonencode(local.logfiles)

--- a/modules/runners/policies-runner.tf
+++ b/modules/runners/policies-runner.tf
@@ -45,3 +45,5 @@ resource "aws_iam_role_policy_attachment" "managed_policies" {
   role       = aws_iam_role.runner.name
   policy_arn = element(var.runner_iam_role_managed_policy_arns, count.index)
 }
+
+// see also logging.tf for logging and metrics policies

--- a/modules/runners/policies/instance-cloudwatch-policy.json
+++ b/modules/runners/policies/instance-cloudwatch-policy.json
@@ -1,0 +1,25 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:PutMetricData",
+                "ec2:DescribeVolumes",
+                "ec2:DescribeTags",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams",
+                "logs:DescribeLogGroups",
+                "logs:CreateLogStream"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameter"
+            ],
+            "Resource": "${ssm_parameter_arn}/*"
+        }
+    ]
+}


### PR DESCRIPTION
Policies for runner insance are missing to write to logstrea, read from parameter store and write metrics.

Fix #388 