### PR TITLE
Allow configuring additional security groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,16 +74,17 @@ module "runners" {
   ami_filter          = local.ami_filter
   ami_owners          = var.ami_owners
 
-  sqs_build_queue                 = aws_sqs_queue.queued_builds
-  github_app                      = var.github_app
-  enable_organization_runners     = var.enable_organization_runners
-  scale_down_schedule_expression  = var.scale_down_schedule_expression
-  minimum_running_time_in_minutes = var.minimum_running_time_in_minutes
-  runner_extra_labels             = var.runner_extra_labels
-  runner_as_root                  = var.runner_as_root
-  runners_maximum_count           = var.runners_maximum_count
-  idle_config                     = var.idle_config
-  enable_ssm_on_runners           = var.enable_ssm_on_runners
+  sqs_build_queue                      = aws_sqs_queue.queued_builds
+  github_app                           = var.github_app
+  enable_organization_runners          = var.enable_organization_runners
+  scale_down_schedule_expression       = var.scale_down_schedule_expression
+  minimum_running_time_in_minutes      = var.minimum_running_time_in_minutes
+  runner_extra_labels                  = var.runner_extra_labels
+  runner_as_root                       = var.runner_as_root
+  runners_maximum_count                = var.runners_maximum_count
+  idle_config                          = var.idle_config
+  enable_ssm_on_runners                = var.enable_ssm_on_runners
+  runner_additional_security_group_ids = var.runner_additional_security_group_ids
 
   lambda_s3_bucket                 = var.lambda_s3_bucket
   runners_lambda_s3_key            = var.runners_lambda_s3_key

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -62,7 +62,10 @@ resource "aws_launch_template" "runner" {
   image_id      = data.aws_ami.runner.id
   instance_type = var.instance_type
 
-  vpc_security_group_ids = [aws_security_group.runner_sg.id]
+  vpc_security_group_ids = compact(concat(
+    [aws_security_group.runner_sg.id],
+    var.runner_additional_security_group_ids,
+  ))
 
   tag_specifications {
     resource_type = "instance"

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -278,3 +278,9 @@ variable "runner_log_files" {
     }
   ]
 }
+
+variable "runner_additional_security_group_ids" {
+  description = "(optional) List of additional security groups IDs to apply to the runner"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -296,3 +296,9 @@ variable "runner_log_files" {
     }
   ]
 }
+
+variable "runner_additional_security_group_ids" {
+  description = "(optional) List of additional security groups IDs to apply to the runner"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
We've started recently looking to use this module and to fit it into our current infrastructure we'd like to be able to attach additional security groups to the runners. This will enable us to SSH to them which will help us debug some small customisations we're making in the user data.
