### PR TITLE
copy directory *after* installing zip

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,12 +1,12 @@
 FROM node:12
 
-WORKDIR /lambda
-
-COPY . /lambda
-
 RUN apt-get update \
     && apt-get install -y zip \
     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /lambda
+
+COPY . /lambda
 
 RUN yarn install \
     && yarn run dist


### PR DESCRIPTION
This should allow the `.ci/build` script to cache the `zip` installation layer between builds hopefully improving the build times slightly when starting fresh :smile:

![switch places](https://media.giphy.com/media/xUNd9TPUlfyyo8uuHe/giphy.gif)