### PR TITLE
Queue visibility time has to be >= lambda timeout

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "random_string" "random" {
 resource "aws_sqs_queue" "queued_builds" {
   name                        = "${var.environment}-queued-builds.fifo"
   delay_seconds               = 30
-  visibility_timeout_seconds  = 60
+  visibility_timeout_seconds  = var.runners_scale_up_lambda_timeout
   fifo_queue                  = true
   receive_wait_time_seconds   = 10
   content_based_deduplication = true


### PR DESCRIPTION
* AWS SQS queue visibility times have to be >= the timeout of the associated lambda: [source](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)

* error to do so will result in a terraform provisioning error during initial resource creation of `module.runners.module.runners.aws_lambda_event_source_mapping.scale_up`:
```bash
terraform apply
...
module.runners.module.runners.aws_lambda_event_source_mapping.scale_up: Still creating... [4m20s elapsed]
module.runners.module.runners.aws_lambda_event_source_mapping.scale_up: Still creating... [4m30s elapsed]
module.runners.module.runners.aws_lambda_event_source_mapping.scale_up: Still creating... [4m40s elapsed]
module.runners.module.runners.aws_lambda_event_source_mapping.scale_up: Still creating... [4m50s elapsed]

Error: Error creating Lambda event source mapping: InvalidParameterValueException: Queue visibility timeout: 60 seconds is less than Function timeout: 180 seconds
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "e6da5176-e0d8-4a81-a34b-378624b78b74"
  },
  Message_: "Queue visibility timeout: 60 seconds is less than Function timeout: 180 seconds",
  Type: "User"
}
```

Apparently, the constraint is not causing terraform to fail when trying to modify `module.runners.module.runners.aws_lambda_event_source_mapping.scale_up` with a smaller value afterwards:

```bash
terraform apply
...
# module.runners.aws_sqs_queue.queued_builds will be updated in-place
  ~ resource "aws_sqs_queue" "queued_builds" {
        id                                = "https://sqs.eu-west-1.amazonaws.com/869946923544/default-queued-builds.fifo"
        name                              = "default-queued-builds.fifo"
        tags                              = {
            "Project" = "octodemo-baseline-terraform-aws-github-runner"
        }
      ~ visibility_timeout_seconds        = 180 -> 60
        # (8 unchanged attributes hidden)
    }
...
module.runners.module.runners.aws_lambda_function.scale_up: Modifications complete after 6s [id=default-scale-up]
```
... which may explain how this problem went unnoticed so far

* setting `module.runners.aws_sqs_queue.queued_builds.visibility_timeout_seconds`  to `module.runners.module.runners.aws_lambda_function.scale_up.timeout` solves the issue at initial resource creation time