### PR TITLE
Retrieve installation id automatically if not present (triggered by ordinary webhook)

### DIFF
--- a/modules/webhook/lambdas/webhook/src/webhook/handler.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.ts
@@ -41,13 +41,17 @@ export const handle = async (headers: IncomingHttpHeaders, payload: any): Promis
 
   if (githubEvent === 'check_run') {
     const body = JSON.parse(payload) as EventPayloads.WebhookPayloadCheckRun;
+    let installationId = body.installation?.id
+    if (installationId == null) {
+      installationId = 0
+    }
     if (body.action === 'created' && body.check_run.status === 'queued') {
       await sendActionRequest({
         id: body.check_run.id,
         repositoryName: body.repository.name,
         repositoryOwner: body.repository.owner.login,
         eventType: githubEvent,
-        installationId: body.installation!.id,
+        installationId: installationId
       });
     }
   } else {


### PR DESCRIPTION
tl;dr Make it possible to reuse one GitHub App for multiple mostly indeoendent environments in combination with ordinary web hooks

### Problem statement 

If multiple mostly independent groups like to share the same GitHub App for their organizations (different installation ids), but like to use isolated environments of the AWS GitHub Runner, they face a problem as a GitHub App can only have one single webhook and secret configured - independent on how many orgs have installed it.

### Solution and problem to solve

 As the different runner installations have different secrets and different endpoints, one solution would be to just install the App in the org but then register an org or repository webhook that listens on the `check_run` event and point it to the address of the corresponding AWS API endpoint. However - ordinary webhook payloads do not contain any installation ids in them, causing the webhook lambda to fail with an NPE.

### Fix in this PR

This PR checks whether the webhook event payload contains an installation id. If not, it will set the installation id to 0 which is a value that is guaranteed to not occur for "real" installation ids. The scale up lambda is then checking for the 0 value and if it finds it, it will lookup the correct installation id for the organization/repo in question.
In case a web hook from a GitHub App is received, the control flow does not change (no additional calls introduced).

