### PR TITLE
fix: broken vpc module in examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.30.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_tflint

--- a/examples/default/vpc.tf
+++ b/examples/default/vpc.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source = "git::https://github.com/philips-software/terraform-aws-vpc.git?ref=2.1.0"
+  source = "git::https://github.com/philips-software/terraform-aws-vpc.git?ref=2.2.0"
 
   environment                = local.environment
   aws_region                 = local.aws_region

--- a/examples/ubuntu/vpc.tf
+++ b/examples/ubuntu/vpc.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source = "git::https://github.com/philips-software/terraform-aws-vpc.git?ref=2.1.0"
+  source = "git::https://github.com/philips-software/terraform-aws-vpc.git?ref=2.2.0"
 
   environment                = local.environment
   aws_region                 = local.aws_region

--- a/modules/download-lambda/README.md
+++ b/modules/download-lambda/README.md
@@ -32,20 +32,20 @@ No requirements.
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
-| null | n/a     |
+|------|---------|
+| null | n/a |
 
 ## Inputs
 
-| Name    | Description                           | Type                                                                        | Default | Required |
-| ------- | ------------------------------------- | --------------------------------------------------------------------------- | ------- | :------: |
-| lambdas | Name and tag for lambdas to download. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | n/a     |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| lambdas | Name and tag for lambdas to download. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 
-| Name  | Description |
-| ----- | ----------- |
-| files | n/a         |
+| Name | Description |
+|------|-------------|
+| files | n/a |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 


### PR DESCRIPTION
Creating the vpc results in the following error:

```
Error: multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service
```

Upgrade vpc module is solving the issue.
