### PR TITLE
Pass runner_group_name forward

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,6 +98,7 @@ module "runners" {
   enable_cloudwatch_agent          = var.enable_cloudwatch_agent
   cloudwatch_config                = var.cloudwatch_config
   runner_log_files                 = var.runner_log_files
+  runner_group_name                = var.runner_group_name
 
   instance_profile_path     = var.instance_profile_path
   role_path                 = var.role_path


### PR DESCRIPTION
The top-level module is currently not passing `runner_group_name` to the `runners` module.