### PR TITLE
Allow setting the market_options runners module value

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ No requirements.
 | lambda\_subnet\_ids | List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_id`. | `list(string)` | `[]` | no |
 | logging\_retention\_in\_days | Specifies the number of days you want to retain log events for the lambda log group. Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. | `number` | `180` | no |
 | manage\_kms\_key | Let the module manage the KMS key. | `bool` | `true` | no |
-| market\_options | Set it to null for to use on demand runners. | `string` | `"spot"` | no |
+| market\_options | Set it to null to use on demand runners. | `string` | `"spot"` | no |
 | minimum\_running\_time\_in\_minutes | The time an ec2 action runner should be running at minimum before terminated if non busy. | `number` | `5` | no |
 | role\_path | The path that will be added to role path for created roles, if not set the environment name will be used. | `string` | `null` | no |
 | role\_permissions\_boundary | Permissions boundary that will be added to the created roles. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ No requirements.
 | lambda\_subnet\_ids | List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_id`. | `list(string)` | `[]` | no |
 | logging\_retention\_in\_days | Specifies the number of days you want to retain log events for the lambda log group. Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. | `number` | `180` | no |
 | manage\_kms\_key | Let the module manage the KMS key. | `bool` | `true` | no |
+| market\_options | Set it to null for to use on demand runners. | `string` | `"spot"` | no |
 | minimum\_running\_time\_in\_minutes | The time an ec2 action runner should be running at minimum before terminated if non busy. | `number` | `5` | no |
 | role\_path | The path that will be added to role path for created roles, if not set the environment name will be used. | `string` | `null` | no |
 | role\_permissions\_boundary | Permissions boundary that will be added to the created roles. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,7 @@ module "runners" {
   s3_location_runner_binaries = local.s3_action_runner_url
 
   instance_type         = var.instance_type
+  market_options        = var.market_options
   block_device_mappings = var.block_device_mappings
 
   runner_architecture = local.runner_architecture

--- a/variables.tf
+++ b/variables.tf
@@ -342,7 +342,7 @@ variable "runner_additional_security_group_ids" {
 }
 
 variable "market_options" {
-  description = "Market options for the action runner instances."
+  description = "Market options for the action runner instances. Setting the value to `null` let the scaler create on-demand instances instead of spot instanes."
   type        = string
   default     = "spot"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -340,3 +340,9 @@ variable "runner_additional_security_group_ids" {
   type        = list(string)
   default     = []
 }
+
+variable "market_options" {
+  description = "Market options for the action runner instances."
+  type        = string
+  default     = "spot"
+}


### PR DESCRIPTION
In order to be able to use on_demand runners