### PR TITLE
fix: dependabot approve

### DIFF
--- a/.github/workflows/auto-approve-dependabot.yml
+++ b/.github/workflows/auto-approve-dependabot.yml
@@ -1,11 +1,19 @@
 name: Auto approve dependabot
-on: pull_request
+
+# Warning: The pull_request_target event is granted a read/write repository
+# token and can access secrets, even when it is triggered from a fork. Although
+# the workflow runs in the context of the base of the pull request, you should
+# make sure that you do not check out, build, or run untrusted code from the
+# pull request with this event. Additionally, any caches share the same scope as
+# the base branch, and to help prevent cache poisoning, you should not save the
+# cache if there is a possibility that the cache contents were altered. 
+on: pull_request_target
 
 jobs:
-  build:
+  approve:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Due to changes in github permisson model run the PR's for dependabot on base

https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/