### PR TITLE
Update Webhook check_run Event Subscription Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Go back to the GitHub App and update the following settings.
 1. Enable the webhook.
 2. Provide the webhook url, should be part of the output of terraform.
 3. Provide the webhook secret.
-4. Enable the `check_run` event for the webhook.
+4. In the "Permissions & Events" section and then "Subscribe to Events" subsection, check "Check Run".
 5. In the "Install App" section, install the App in your organization, either in all or in selected repositories.
 
 You are now ready to run action workloads on self hosted runner. Remember that builds will fail if there is no (offline) runner available with matching labels.


### PR DESCRIPTION
The way to configure subscribing to the `check_run` events on GitHub has apparently changed. It is now under the "Permissions & Events" section:

![image](https://user-images.githubusercontent.com/966764/113977329-63585780-987d-11eb-8f34-a8e8d907503f.png)
