### PR TITLE
fix: change Ubuntu example to log syslog instead of messages

### DIFF
--- a/examples/ubuntu/main.tf
+++ b/examples/ubuntu/main.tf
@@ -51,9 +51,9 @@ module "runners" {
 
   runner_log_files = [
     {
-      "log_group_name" : "messages",
+      "log_group_name" : "syslog",
       "prefix_log_group" : true,
-      "file_path" : "/var/log/messages",
+      "file_path" : "/var/log/syslog",
       "log_stream_name" : "{instance_id}"
     },
     {


### PR DESCRIPTION
Unlike RHEL and CentOS, Ubuntu writes logs to `/var/log/syslog` instead of to `/var/log/messages`. This might have been different in the past.

This fixes #783.