### PR TITLE
Make module lambda-download fail when wrong tag is set

### DIFF
--- a/modules/download-lambda/main.tf
+++ b/modules/download-lambda/main.tf
@@ -8,6 +8,6 @@ resource "null_resource" "download" {
   }
 
   provisioner "local-exec" {
-    command = "curl -o ${self.triggers.file} -L https://github.com/philips-labs/terraform-aws-github-runner/releases/download/${self.triggers.tag}/${self.triggers.name}.zip"
+    command = "curl -o ${self.triggers.file} -fL https://github.com/philips-labs/terraform-aws-github-runner/releases/download/${self.triggers.tag}/${self.triggers.name}.zip"
   }
 }


### PR DESCRIPTION
Currently output zip file contains text "404 Not found" and `terraform apply` reports success

Closes #838 