### PR TITLE
Support Multiple Instance Types

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,7 @@ module "runners" {
   s3_location_runner_binaries = local.s3_action_runner_url
 
   instance_type         = var.instance_type
+  instance_types        = var.instance_types
   market_options        = var.market_options
   block_device_mappings = var.block_device_mappings
 

--- a/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -1,5 +1,4 @@
-import { listRunners, RunnerInfo, createRunner } from './runners';
-import { EC2, SSM } from 'aws-sdk';
+import { listRunners, createRunner } from './runners';
 
 const mockEC2 = { describeInstances: jest.fn(), runInstances: jest.fn() };
 const mockSSM = { putParameter: jest.fn() };
@@ -7,6 +6,10 @@ jest.mock('aws-sdk', () => ({
   EC2: jest.fn().mockImplementation(() => mockEC2),
   SSM: jest.fn().mockImplementation(() => mockSSM),
 }));
+
+const ORG_NAME = 'SomeAwesomeCoder';
+const REPO_NAME = `${ORG_NAME}/some-amazing-library`;
+const ENVIRONMENT = 'unit-test-environment';
 
 describe('list instances', () => {
   const mockDescribeInstances = { promise: jest.fn() };
@@ -30,8 +33,8 @@ describe('list instances', () => {
               LaunchTime: new Date('2020-10-11T14:48:00.000+09:00'),
               InstanceId: 'i-5678',
               Tags: [
-                { Key: 'Repo', Value: 'SomeAwesomeCoder/some-amazing-library' },
-                { Key: 'Org', Value: 'SomeAwesomeCoder' },
+                { Key: 'Repo', Value: REPO_NAME },
+                { Key: 'Org', Value: ORG_NAME },
                 { Key: 'Application', Value: 'github-action-runner' },
               ],
             },
@@ -54,8 +57,8 @@ describe('list instances', () => {
     expect(resp).toContainEqual({
       instanceId: 'i-5678',
       launchTime: new Date('2020-10-11T14:48:00.000+09:00'),
-      repo: 'SomeAwesomeCoder/some-amazing-library',
-      org: 'SomeAwesomeCoder',
+      repo: REPO_NAME,
+      org: ORG_NAME,
     });
   });
 
@@ -65,46 +68,34 @@ describe('list instances', () => {
   });
 
   it('filters instances on repo name', async () => {
-    await listRunners({ repoName: 'SomeAwesomeCoder/some-amazing-library' });
+    await listRunners({ runnerType: 'Repo', runnerOwner: REPO_NAME });
     expect(mockEC2.describeInstances).toBeCalledWith({
       Filters: [
         { Name: 'tag:Application', Values: ['github-action-runner'] },
         { Name: 'instance-state-name', Values: ['running', 'pending'] },
-        { Name: 'tag:Repo', Values: ['SomeAwesomeCoder/some-amazing-library'] },
+        { Name: 'tag:Repo', Values: [REPO_NAME] },
       ],
     });
   });
 
   it('filters instances on org name', async () => {
-    await listRunners({ orgName: 'SomeAwesomeCoder' });
+    await listRunners({ runnerType: 'Org', runnerOwner: ORG_NAME });
     expect(mockEC2.describeInstances).toBeCalledWith({
       Filters: [
         { Name: 'tag:Application', Values: ['github-action-runner'] },
         { Name: 'instance-state-name', Values: ['running', 'pending'] },
-        { Name: 'tag:Org', Values: ['SomeAwesomeCoder'] },
+        { Name: 'tag:Org', Values: [ORG_NAME] },
       ],
     });
   });
 
   it('filters instances on org name', async () => {
-    await listRunners({ environment: 'unit-test-environment' });
+    await listRunners({ environment: ENVIRONMENT });
     expect(mockEC2.describeInstances).toBeCalledWith({
       Filters: [
         { Name: 'tag:Application', Values: ['github-action-runner'] },
         { Name: 'instance-state-name', Values: ['running', 'pending'] },
-        { Name: 'tag:Environment', Values: ['unit-test-environment'] },
-      ],
-    });
-  });
-
-  it('filters instances on both org name and repo name', async () => {
-    await listRunners({ orgName: 'SomeAwesomeCoder', repoName: 'SomeAwesomeCoder/some-amazing-library' });
-    expect(mockEC2.describeInstances).toBeCalledWith({
-      Filters: [
-        { Name: 'tag:Application', Values: ['github-action-runner'] },
-        { Name: 'instance-state-name', Values: ['running', 'pending'] },
-        { Name: 'tag:Repo', Values: ['SomeAwesomeCoder/some-amazing-library'] },
-        { Name: 'tag:Org', Values: ['SomeAwesomeCoder'] },
+        { Name: 'tag:Environment', Values: [ENVIRONMENT] },
       ],
     });
   });
@@ -132,9 +123,9 @@ describe('create runner', () => {
   it('calls run instances with the correct config for repo', async () => {
     await createRunner({
       runnerConfig: 'bla',
-      environment: 'unit-test-env',
-      repoName: 'SomeAwesomeCoder/some-amazing-library',
-      orgName: undefined,
+      environment: ENVIRONMENT,
+      runnerType: 'Repo',
+      runnerOwner: REPO_NAME
     });
     expect(mockEC2.runInstances).toBeCalledWith({
       MaxCount: 1,
@@ -146,7 +137,7 @@ describe('create runner', () => {
           ResourceType: 'instance',
           Tags: [
             { Key: 'Application', Value: 'github-action-runner' },
-            { Key: 'Repo', Value: 'SomeAwesomeCoder/some-amazing-library' },
+            { Key: 'Repo', Value: REPO_NAME },
           ],
         },
       ],
@@ -156,9 +147,9 @@ describe('create runner', () => {
   it('calls run instances with the correct config for org', async () => {
     await createRunner({
       runnerConfig: 'bla',
-      environment: 'unit-test-env',
-      repoName: undefined,
-      orgName: 'SomeAwesomeCoder',
+      environment: ENVIRONMENT,
+      runnerType: 'Org',
+      runnerOwner: ORG_NAME,
     });
     expect(mockEC2.runInstances).toBeCalledWith({
       MaxCount: 1,
@@ -170,7 +161,7 @@ describe('create runner', () => {
           ResourceType: 'instance',
           Tags: [
             { Key: 'Application', Value: 'github-action-runner' },
-            { Key: 'Org', Value: 'SomeAwesomeCoder' },
+            { Key: 'Org', Value: ORG_NAME },
           ],
         },
       ],
@@ -180,12 +171,12 @@ describe('create runner', () => {
   it('creates ssm parameters for each created instance', async () => {
     await createRunner({
       runnerConfig: 'bla',
-      environment: 'unit-test-env',
-      repoName: undefined,
-      orgName: 'SomeAwesomeCoder',
+      environment: ENVIRONMENT,
+      runnerType: 'Org',
+      runnerOwner: ORG_NAME,
     });
     expect(mockSSM.putParameter).toBeCalledWith({
-      Name: 'unit-test-env-i-1234',
+      Name: `${ENVIRONMENT}-i-1234`,
       Value: 'bla',
       Type: 'SecureString',
     });
@@ -197,9 +188,9 @@ describe('create runner', () => {
     });
     await createRunner({
       runnerConfig: 'bla',
-      environment: 'unit-test-env',
-      repoName: undefined,
-      orgName: 'SomeAwesomeCoder',
+      environment: ENVIRONMENT,
+      runnerType: 'Org',
+      runnerOwner: ORG_NAME,
     });
     expect(mockSSM.putParameter).not.toBeCalled();
   });

--- a/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/runners.test.ts
@@ -68,7 +68,7 @@ describe('list instances', () => {
   });
 
   it('filters instances on repo name', async () => {
-    await listRunners({ runnerType: 'Repo', runnerOwner: REPO_NAME });
+    await listRunners({ runnerType: 'Repo', runnerOwner: REPO_NAME, environment: undefined });
     expect(mockEC2.describeInstances).toBeCalledWith({
       Filters: [
         { Name: 'tag:Application', Values: ['github-action-runner'] },
@@ -79,7 +79,7 @@ describe('list instances', () => {
   });
 
   it('filters instances on org name', async () => {
-    await listRunners({ runnerType: 'Org', runnerOwner: ORG_NAME });
+    await listRunners({ runnerType: 'Org', runnerOwner: ORG_NAME, environment: undefined });
     expect(mockEC2.describeInstances).toBeCalledWith({
       Filters: [
         { Name: 'tag:Application', Values: ['github-action-runner'] },

--- a/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -8,9 +8,9 @@ export interface RunnerInfo {
 }
 
 export interface ListRunnerFilters {
-  repoName?: string;
-  orgName?: string;
-  environment?: string;
+  runnerType?: 'Org' | 'Repo';
+  runnerOwner?: string;
+  environment?: string | undefined;
 }
 
 export async function listRunners(filters: ListRunnerFilters | undefined = undefined): Promise<RunnerInfo[]> {
@@ -23,11 +23,8 @@ export async function listRunners(filters: ListRunnerFilters | undefined = undef
     if (filters.environment !== undefined) {
       ec2Filters.push({ Name: 'tag:Environment', Values: [filters.environment] });
     }
-    if (filters.repoName !== undefined) {
-      ec2Filters.push({ Name: 'tag:Repo', Values: [filters.repoName] });
-    }
-    if (filters.orgName !== undefined) {
-      ec2Filters.push({ Name: 'tag:Org', Values: [filters.orgName] });
+    if (filters.runnerType && filters.runnerOwner) {
+      ec2Filters.push({ Name: `tag:${filters.runnerType}`, Values: [filters.runnerOwner] });
     }
   }
   const runningInstances = await ec2.describeInstances({ Filters: ec2Filters }).promise();
@@ -52,8 +49,8 @@ export async function listRunners(filters: ListRunnerFilters | undefined = undef
 export interface RunnerInputParameters {
   runnerConfig: string;
   environment: string;
-  repoName?: string;
-  orgName?: string;
+  runnerType: 'Org' | 'Repo';
+  runnerOwner: string;
 }
 
 export async function terminateRunner(runner: RunnerInfo): Promise<void> {
@@ -89,8 +86,8 @@ export async function createRunner(runnerParameters: RunnerInputParameters): Pro
           Tags: [
             { Key: 'Application', Value: 'github-action-runner' },
             {
-              Key: runnerParameters.orgName ? 'Org' : 'Repo',
-              Value: runnerParameters.orgName ? runnerParameters.orgName : runnerParameters.repoName,
+              Key: runnerParameters.runnerType,
+              Value: runnerParameters.runnerOwner
             },
           ],
         },

--- a/modules/runners/lambdas/runners/src/scale-runners/runners.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/runners.ts
@@ -10,7 +10,7 @@ export interface RunnerInfo {
 export interface ListRunnerFilters {
   runnerType?: 'Org' | 'Repo';
   runnerOwner?: string;
-  environment?: string | undefined;
+  environment: string | undefined;
 }
 
 export async function listRunners(filters: ListRunnerFilters | undefined = undefined): Promise<RunnerInfo[]> {

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -139,7 +139,7 @@ export async function scaleDown(): Promise<void> {
   // list and sort runners, newest first. This ensure we keep the newest runners longer.
   const runners = (
     await listRunners({
-      environment: environment,
+      environment
     })
   ).sort((a, b): number => {
     if (a.launchTime === undefined) return 1;

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -126,7 +126,8 @@ describe('scaleUp with GHES', () => {
       await scaleUp('aws:sqs', TEST_DATA);
       expect(listRunners).toBeCalledWith({
         environment: 'unit-test-environment',
-        repoName: undefined,
+        runnerType: 'Org',
+        runnerOwner: TEST_DATA.repositoryOwner
       });
     });
 
@@ -174,8 +175,8 @@ describe('scaleUp with GHES', () => {
       expect(createRunner).toBeCalledWith({
         environment: 'unit-test-environment',
         runnerConfig: `--url https://github.enterprise.something/${TEST_DATA.repositoryOwner} --token 1234abcd `,
-        orgName: TEST_DATA.repositoryOwner,
-        repoName: undefined,
+        runnerType: 'Org',
+        runnerOwner: TEST_DATA.repositoryOwner,
       });
     });
 
@@ -187,8 +188,8 @@ describe('scaleUp with GHES', () => {
         environment: 'unit-test-environment',
         runnerConfig: `--url https://github.enterprise.something/${TEST_DATA.repositoryOwner} ` +
           `--token 1234abcd --labels label1,label2 --runnergroup TEST_GROUP`,
-        orgName: TEST_DATA.repositoryOwner,
-        repoName: undefined,
+        runnerType: 'Org',
+        runnerOwner: TEST_DATA.repositoryOwner,
       });
     });
   });
@@ -202,7 +203,8 @@ describe('scaleUp with GHES', () => {
       await scaleUp('aws:sqs', TEST_DATA);
       expect(listRunners).toBeCalledWith({
         environment: 'unit-test-environment',
-        repoName: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
+        runnerType: 'Repo',
+        runnerOwner: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
       });
     });
 
@@ -253,8 +255,8 @@ describe('scaleUp with GHES', () => {
         runnerConfig: `--url ` +
           `https://github.enterprise.something/${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName} ` +
           `--token 1234abcd --labels label1,label2`,
-        orgName: undefined,
-        repoName: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
+        runnerType: 'Repo',
+        runnerOwner: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
       });
     });
 
@@ -267,8 +269,8 @@ describe('scaleUp with GHES', () => {
         runnerConfig: `--url ` +
           `https://github.enterprise.something/${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName} ` +
           `--token 1234abcd --labels label1,label2`,
-        orgName: undefined,
-        repoName: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
+        runnerType: 'Repo',
+        runnerOwner: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
       });
     });
   });
@@ -322,7 +324,8 @@ describe('scaleUp with public GH', () => {
       await scaleUp('aws:sqs', TEST_DATA);
       expect(listRunners).toBeCalledWith({
         environment: 'unit-test-environment',
-        repoName: undefined,
+        runnerType: 'Org',
+        runnerOwner: TEST_DATA.repositoryOwner
       });
     });
 
@@ -345,8 +348,8 @@ describe('scaleUp with public GH', () => {
       expect(createRunner).toBeCalledWith({
         environment: 'unit-test-environment',
         runnerConfig: `--url https://github.com/${TEST_DATA.repositoryOwner} --token 1234abcd `,
-        orgName: TEST_DATA.repositoryOwner,
-        repoName: undefined,
+        runnerType: 'Org',
+        runnerOwner: TEST_DATA.repositoryOwner
       });
     });
 
@@ -358,8 +361,8 @@ describe('scaleUp with public GH', () => {
         environment: 'unit-test-environment',
         runnerConfig: `--url https://github.com/${TEST_DATA.repositoryOwner} ` +
           `--token 1234abcd --labels label1,label2 --runnergroup TEST_GROUP`,
-        orgName: TEST_DATA.repositoryOwner,
-        repoName: undefined,
+        runnerType: 'Org',
+        runnerOwner: TEST_DATA.repositoryOwner
       });
     });
   });
@@ -373,7 +376,8 @@ describe('scaleUp with public GH', () => {
       await scaleUp('aws:sqs', TEST_DATA);
       expect(listRunners).toBeCalledWith({
         environment: 'unit-test-environment',
-        repoName: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
+        runnerType: 'Repo',
+        runnerOwner: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
       });
     });
 
@@ -414,8 +418,8 @@ describe('scaleUp with public GH', () => {
         environment: 'unit-test-environment',
         runnerConfig: `--url https://github.com/${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName} ` +
           `--token 1234abcd --labels label1,label2`,
-        orgName: undefined,
-        repoName: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
+        runnerType: 'Repo',
+        runnerOwner: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
       });
     });
 
@@ -427,8 +431,8 @@ describe('scaleUp with public GH', () => {
         environment: 'unit-test-environment',
         runnerConfig: `--url https://github.com/${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName} ` +
           `--token 1234abcd --labels label1,label2`,
-        orgName: undefined,
-        repoName: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
+        runnerType: 'Repo',
+        runnerOwner: `${TEST_DATA.repositoryOwner}/${TEST_DATA.repositoryName}`,
       });
     });
   });

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -203,6 +203,17 @@ describe('scaleUp with GHES', () => {
       expect(createRunner).toBeCalledTimes(2);
       expect(createRunner).toHaveBeenNthCalledWith(1, expectedRunnerParams, 'lt-1');
       expect(createRunner).toHaveBeenNthCalledWith(2, expectedRunnerParams, 'lt-2');
+      mockCreateRunners.mockReset();
+    });
+
+    it('all launch templates fail', async () => {
+      const mockCreateRunners = mocked(createRunner);
+      mockCreateRunners.mockRejectedValue(new Error('All launch templates failed'));
+      await expect(scaleUpModule.scaleUp('aws:sqs', TEST_DATA)).rejects.toThrow('All launch templates failed');
+      expect(createRunner).toBeCalledTimes(2);
+      expect(createRunner).toHaveBeenNthCalledWith(1, expectedRunnerParams, 'lt-1');
+      expect(createRunner).toHaveBeenNthCalledWith(2, expectedRunnerParams, 'lt-2');
+      mockCreateRunners.mockReset();
     });
   });
 

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -96,14 +96,18 @@ export const scaleUp = async (eventSource: string, payload: ActionRequestMessage
 
 export async function createRunnerLoop(runnerParameters: RunnerInputParameters): Promise<void> {
   const launchTemplateNames = process.env.LAUNCH_TEMPLATE_NAME?.split(',') as string[];
+  let launched = false;
   for (const launchTemplateName of launchTemplateNames) {
     console.info(`Attempting to launch instance using ${launchTemplateName}.`);
     try {
       await createRunner(runnerParameters, launchTemplateName);
+      launched = true;
       break;
     } catch (error) {
-      console.error(error.message);
-      throw error;
+      console.error(error);
     }
+  }
+  if (launched == false) {
+    throw Error('All launch templates failed');
   }
 }

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -1,4 +1,4 @@
-import { listRunners, createRunner } from './runners';
+import { listRunners, createRunner, RunnerInputParameters } from './runners';
 import { createOctoClient, createGithubAuth } from './gh-auth';
 import yn from 'yn';
 
@@ -77,16 +77,33 @@ export const scaleUp = async (eventSource: string, payload: ActionRequestMessage
       const labelsArgument = runnerExtraLabels !== undefined ? `--labels ${runnerExtraLabels}` : '';
       const runnerGroupArgument = runnerGroup !== undefined ? ` --runnergroup ${runnerGroup}` : '';
       const configBaseUrl = ghesBaseUrl ? ghesBaseUrl : 'https://github.com';
-      await createRunner({
-        environment: environment,
-        runnerConfig: enableOrgLevel
-          ? `--url ${configBaseUrl}/${runnerOwner} --token ${token} ${labelsArgument}${runnerGroupArgument}`
-          : `--url ${configBaseUrl}/${runnerOwner} --token ${token} ${labelsArgument}`,
-        runnerType,
+
+      await createRunnerLoop({
+        environment,
+        runnerServiceConfig: enableOrgLevel
+          ? `--url ${configBaseUrl}/${payload.repositoryOwner} --token ${token} ${labelsArgument}${runnerGroupArgument}`
+          : `--url ${configBaseUrl}/${payload.repositoryOwner}/${payload.repositoryName} ` +
+          `--token ${token} ${labelsArgument}`,
         runnerOwner,
+        runnerType
+
       });
     } else {
       console.info('No runner will be created, maximum number of runners reached.');
     }
   }
 };
+
+export async function createRunnerLoop(runnerParameters: RunnerInputParameters): Promise<void> {
+  const launchTemplateNames = process.env.LAUNCH_TEMPLATE_NAME?.split(',') as string[];
+  for (const launchTemplateName of launchTemplateNames) {
+    console.info(`Attempting to launch instance using ${launchTemplateName}.`);
+    try {
+      await createRunner(runnerParameters, launchTemplateName);
+      break;
+    } catch (error) {
+      console.error(error.message);
+      throw error;
+    }
+  }
+}

--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -39,8 +39,7 @@ resource "aws_lambda_function" "scale_up" {
       RUNNER_EXTRA_LABELS         = var.runner_extra_labels
       RUNNER_GROUP_NAME           = var.runner_group_name
       RUNNERS_MAXIMUM_COUNT       = var.runners_maximum_count
-      LAUNCH_TEMPLATE_NAME        = aws_launch_template.runner.name
-      LAUNCH_TEMPLATE_VERSION     = aws_launch_template.runner.latest_version
+      LAUNCH_TEMPLATE_NAME        = join(",", [for template in aws_launch_template.runner : template.name])
       SUBNET_IDS                  = join(",", var.subnet_ids)
     }
   }

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -58,7 +58,7 @@ variable "market_options" {
 }
 
 variable "instance_type" {
-  description = "Default instance type for the action runner."
+  description = "[DEPRECATED] See instance_types."
   type        = string
   default     = "m5.large"
 }

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -63,6 +63,12 @@ variable "instance_type" {
   default     = "m5.large"
 }
 
+variable "instance_types" {
+  description = "List of instance types for the action runner."
+  type        = set(string)
+  default     = null
+}
+
 variable "ami_filter" {
   description = "List of maps used to create the AMI filter for the action runner AMI."
   type        = map(list(string))

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,8 @@
 output "runners" {
   value = {
-    launch_template_name    = module.runners.launch_template.name
-    launch_template_id      = module.runners.launch_template.id
-    launch_template_version = module.runners.launch_template.latest_version
+    launch_template_name    = [for template in module.runners.launch_template : template.name]
+    launch_template_id      = [for template in module.runners.launch_template : template.id]
+    launch_template_version = [for template in module.runners.launch_template : template.latest_version]
     lambda_up               = module.runners.lambda_scale_up
     lambda_down             = module.runners.lambda_scale_down
     role_runner             = module.runners.role_runner

--- a/variables.tf
+++ b/variables.tf
@@ -354,3 +354,9 @@ variable "volume_size" {
   type        = number
   default     = 30
 }
+
+variable "instance_types" {
+  description = "List of instance types for the action runner."
+  type        = set(string)
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -126,7 +126,7 @@ variable "instance_profile_path" {
 }
 
 variable "instance_type" {
-  description = "Instance type for the action runner."
+  description = "[DEPRECATED] See instance_types."
   type        = string
   default     = "m5.large"
 }


### PR DESCRIPTION
This PR adds support for multiple spot instance types.

- Creates a launch template for each type
- Set the default template version to `$LATEST`

Changes from #871 merged to this branch. That PR needs to be merged first.