### PR TITLE
Add support for white listing of repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This [Terraform](https://www.terraform.io/) module creates the required infrastr
 - [Debugging](#debugging)
 - [Requirements](#requirements)
 - [Providers](#providers)
+- [Modules](#modules)
+- [Resources](#resources)
 - [Inputs](#inputs)
 - [Outputs](#outputs)
 - [Contribution](#contribution)
@@ -366,6 +368,7 @@ No requirements.
 | manage\_kms\_key | Let the module manage the KMS key. | `bool` | `true` | no |
 | market\_options | Market options for the action runner instances. Setting the value to `null` let the scaler create on-demand instances instead of spot instances. | `string` | `"spot"` | no |
 | minimum\_running\_time\_in\_minutes | The time an ec2 action runner should be running at minimum before terminated if non busy. | `number` | `5` | no |
+| repository\_white\_list | (optional) List of github repository full names (owner/repo_name) that will be allowed to call the runners. Leave empty for no filtering | `list(string)` | `[]` | no |
 | role\_path | The path that will be added to role path for created roles, if not set the environment name will be used. | `string` | `null` | no |
 | role\_permissions\_boundary | Permissions boundary that will be added to the created roles. | `string` | `null` | no |
 | runner\_additional\_security\_group\_ids | (optional) List of additional security groups IDs to apply to the runner | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ module "webhook" {
 
   role_path                 = var.role_path
   role_permissions_boundary = var.role_permissions_boundary
+  repository_white_list     = var.webhook_repository_white_list
 }
 
 module "runners" {

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ module "webhook" {
 
   role_path                 = var.role_path
   role_permissions_boundary = var.role_permissions_boundary
-  repository_white_list     = var.webhook_repository_white_list
+  repository_white_list     = var.repository_white_list
 }
 
 module "runners" {

--- a/modules/webhook/README.md
+++ b/modules/webhook/README.md
@@ -56,6 +56,7 @@ No requirements.
 | lambda\_timeout | Time out of the lambda in seconds. | `number` | `10` | no |
 | lambda\_zip | File location of the lambda zip file. | `string` | `null` | no |
 | logging\_retention\_in\_days | Specifies the number of days you want to retain log events for the lambda log group. Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. | `number` | `7` | no |
+| repository\_white\_list | List of github repository full names (owner/repo_name) that will be allowed to call the runners. Leave empty for no filtering | `list(string)` | `[]` | no |
 | role\_path | The path that will be added to the role, if not set the environment name will be used. | `string` | `null` | no |
 | role\_permissions\_boundary | Permissions boundary that will be added to the created role for the lambda. | `string` | `null` | no |
 | sqs\_build\_queue | SQS queue to publish accepted build events. | <pre>object({<br>    id  = string<br>    arn = string<br>  })</pre> | n/a | yes |

--- a/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
@@ -83,4 +83,14 @@ describe('handler', () => {
     expect(sendActionRequest).not.toBeCalled();
   });
 
+  it('handles check_run events from whitelisted repositories', async () => {
+    process.env.REPOSITORY_WHITE_LIST = '["Codertocat/Hello-World"]';
+    const resp = await handle(
+      { 'X-Hub-Signature': 'sha1=4a82d2f60346e16dab3546eb3b56d8dde4d5b659', 'X-GitHub-Event': 'check_run' },
+      JSON.stringify(check_run_event),
+    );
+    expect(resp).toBe(200);
+    expect(sendActionRequest).toBeCalled();
+  });
+
 });

--- a/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
@@ -14,6 +14,7 @@ describe('handler', () => {
   let originalError: Console['error'];
 
   beforeEach(() => {
+    process.env.REPOSITORY_WHITE_LIST = '[]';
     process.env.GITHUB_APP_WEBHOOK_SECRET = 'TEST_SECRET';
     originalError = console.error;
     console.error = jest.fn();
@@ -71,4 +72,5 @@ describe('handler', () => {
     expect(resp).toBe(200);
     expect(sendActionRequest).not.toBeCalled();
   });
+
 });

--- a/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
@@ -73,4 +73,14 @@ describe('handler', () => {
     expect(sendActionRequest).not.toBeCalled();
   });
 
+  it('does not handle check_run events from unlisted repositories', async () => {
+    process.env.REPOSITORY_WHITE_LIST = '["NotCodertocat/Hello-World"]';
+    const resp = await handle(
+      { 'X-Hub-Signature': 'sha1=4a82d2f60346e16dab3546eb3b56d8dde4d5b659', 'X-GitHub-Event': 'check_run' },
+      JSON.stringify(check_run_event),
+    );
+    expect(resp).toBe(500);
+    expect(sendActionRequest).not.toBeCalled();
+  });
+
 });

--- a/modules/webhook/lambdas/webhook/src/webhook/handler.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.ts
@@ -40,6 +40,18 @@ export const handle = async (headers: IncomingHttpHeaders, payload: any): Promis
 
   if (githubEvent === 'check_run') {
     const body = JSON.parse(payload) as CheckRunEvent;
+
+    const repositoryWhiteListEnv = process.env.REPOSITORY_WHITE_LIST as string || "[]";
+    const repositoryWhiteList = JSON.parse(repositoryWhiteListEnv) as Array<string>;
+
+    if (repositoryWhiteList.length > 0) {
+      const repositoryFullName = body.repository.full_name;
+      if (!repositoryWhiteList.includes(repositoryFullName)) {
+        console.error(`Received event from unauthorized repository ${repositoryFullName}`);
+        return 500;
+      }
+    }
+
     let installationId = body.installation?.id;
     if (installationId == null) {
       installationId = 0;

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -79,3 +79,8 @@ variable "webhook_lambda_s3_object_version" {
   default     = null
 }
 
+variable "webhook_repository_white_list" {
+  description = "List of repositories allowed to use the github app"
+  type        = list(string)
+  default     = []
+}

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -79,7 +79,7 @@ variable "webhook_lambda_s3_object_version" {
   default     = null
 }
 
-variable "webhook_repository_white_list" {
+variable "repository_white_list" {
   description = "List of repositories allowed to use the github app"
   type        = list(string)
   default     = []

--- a/modules/webhook/webhook.tf
+++ b/modules/webhook/webhook.tf
@@ -44,6 +44,7 @@ resource "aws_lambda_function" "webhook" {
       KMS_KEY_ID                = var.encryption.kms_key_id
       GITHUB_APP_WEBHOOK_SECRET = local.github_app_webhook_secret
       SQS_URL_WEBHOOK           = var.sqs_build_queue.id
+      REPOSITORY_WHITE_LIST     = jsonencode(var.webhook_repository_white_list)
     }
   }
 

--- a/modules/webhook/webhook.tf
+++ b/modules/webhook/webhook.tf
@@ -44,7 +44,7 @@ resource "aws_lambda_function" "webhook" {
       KMS_KEY_ID                = var.encryption.kms_key_id
       GITHUB_APP_WEBHOOK_SECRET = local.github_app_webhook_secret
       SQS_URL_WEBHOOK           = var.sqs_build_queue.id
-      REPOSITORY_WHITE_LIST     = jsonencode(var.webhook_repository_white_list)
+      REPOSITORY_WHITE_LIST     = jsonencode(var.repository_white_list)
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -360,3 +360,9 @@ variable "instance_types" {
   type        = set(string)
   default     = null
 }
+
+variable "repository_white_list" {
+  description = "List of repositories allowed to use the github app"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Update
Add the ability to set a white list of repositories that are allowed to use the the runners.

## Reason
When creating the github app, github provides two choices: public or private. If an organisation wants to use the github app between multiple organisations they would have to make it public. In that case it would be more secure to have a filtering on which repositories are allowed to use it.

## Changes

Add an environment variable to the webhook lambda which contains a list of repository full names that are allowed to be processed. The filtering is done on the webhook level at the time of receiving events.

The changes are backward compatible

## Author
Signed-off-by: ravenolf <benahmed@soramitsu.co.jp>

