### PR TITLE
fix: reduce permissions required for session manager

### DIFF
--- a/modules/runners/policies-runner.tf
+++ b/modules/runners/policies-runner.tf
@@ -14,10 +14,11 @@ resource "aws_iam_instance_profile" "runner" {
   path = local.instance_profile_path
 }
 
-resource "aws_iam_role_policy_attachment" "runner_session_manager_aws_managed" {
-  count      = var.enable_ssm_on_runners ? 1 : 0
-  role       = aws_iam_role.runner.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+resource "aws_iam_role_policy" "runner_session_manager_aws_managed" {
+  name   = "runner-ssm-session"
+  count  = var.enable_ssm_on_runners ? 1 : 0
+  role   = aws_iam_role.runner.name
+  policy = templatefile("${path.module}/policies/instance-ssm-policy.json", {})
 }
 
 resource "aws_iam_role_policy" "ssm_parameters" {

--- a/modules/runners/policies/instance-ssm-policy.json
+++ b/modules/runners/policies/instance-ssm-policy.json
@@ -1,0 +1,46 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:DescribeAssociation",
+                "ssm:GetDeployablePatchSnapshotForInstance",
+                "ssm:GetDocument",
+                "ssm:DescribeDocument",
+                "ssm:GetManifest",
+                "ssm:ListAssociations",
+                "ssm:ListInstanceAssociations",
+                "ssm:PutInventory",
+                "ssm:PutComplianceItems",
+                "ssm:PutConfigurePackageResult",
+                "ssm:UpdateAssociationStatus",
+                "ssm:UpdateInstanceAssociationStatus",
+                "ssm:UpdateInstanceInformation"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
Runner allows to enable SSM manager for debugging purpose. To reduce the parameters can be read from SSM the default permission is replaces by a custom one without granting access to all parameters.