### PR TITLE
current value turned to default under new variable, for issue #748

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,7 @@ module "runners" {
   runners_maximum_count                = var.runners_maximum_count
   idle_config                          = var.idle_config
   enable_ssm_on_runners                = var.enable_ssm_on_runners
+  egress_rules                         = var.runner_egress_rules
   runner_additional_security_group_ids = var.runner_additional_security_group_ids
   volume_size                          = var.volume_size
 

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -128,12 +128,23 @@ resource "aws_security_group" "runner_sg" {
 
   vpc_id = var.vpc_id
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+  dynamic "egress" {
+    for_each = var.egress_rules
+    iterator = each
+
+    content {
+      cidr_blocks      = each.value.cidr_blocks
+      ipv6_cidr_blocks = each.value.ipv6_cidr_blocks
+      prefix_list_ids  = each.value.prefix_list_ids
+      from_port        = each.value.from_port
+      protocol         = each.value.protocol
+      security_groups  = each.value.security_groups
+      self             = each.value.self
+      to_port          = each.value.to_port
+      description      = each.value.description
+    }
   }
+
   tags = merge(
     local.tags,
     {

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -346,4 +346,15 @@ variable "egress_rules" {
     to_port          = number
     description      = string
   }))
+  default = [{
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+    prefix_list_ids  = null
+    from_port        = 0
+    protocol         = "-1"
+    security_groups  = null
+    self             = null
+    to_port          = 0
+    description      = null
+  }]
 }

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -332,3 +332,18 @@ variable "kms_key_arn" {
   type        = string
   default     = null
 }
+
+variable "egress_rules" {
+  description = "List of egress rules for the GitHub runner instances."
+  type = list(object({
+    cidr_blocks      = list(string)
+    ipv6_cidr_blocks = list(string)
+    prefix_list_ids  = list(string)
+    from_port        = number
+    protocol         = string
+    security_groups  = list(string)
+    self             = bool
+    to_port          = number
+    description      = string
+  }))
+}

--- a/variables.tf
+++ b/variables.tf
@@ -360,3 +360,29 @@ variable "delay_webhook_event" {
   type        = number
   default     = 30
 }
+
+variable "runner_egress_rules" {
+  description = "List of egress rules for the GitHub runner instances."
+  type = list(object({
+    cidr_blocks      = list(string)
+    ipv6_cidr_blocks = list(string)
+    prefix_list_ids  = list(string)
+    from_port        = number
+    protocol         = string
+    security_groups  = list(string)
+    self             = bool
+    to_port          = number
+    description      = string
+  }))
+  default = [{
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+    prefix_list_ids  = null
+    from_port        = 0
+    protocol         = "-1"
+    security_groups  = null
+    self             = null
+    to_port          = 0
+    description      = null
+  }]
+}


### PR DESCRIPTION
Proposed code changes to accommodate custom default egress rules, as discussed under issue #748.

Inspired by the GitLab runners code as mentioned under that issue.

Early feedback on these changes is most welcome!

Also, terraform-docs on my end seems to change a lot of the formatting in the README.md files. Am I missing or not doing something obvious? It adds a lot of HTML tags in each line in the tables, hyperlinking to the resources I guess. I'd have thought such formatting should already be present in the current files.
