### PR TITLE
fix(runner): use dynamic block to ignore null market opts

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -63,8 +63,12 @@ resource "aws_launch_template" "runner" {
 
   instance_initiated_shutdown_behavior = "terminate"
 
-  instance_market_options {
-    market_type = var.market_options
+  dynamic "instance_market_options" {
+    for_each = var.market_options != null ? [var.market_options] : []
+
+    content {
+      market_type = instance_market_options.value
+    }
   }
 
   image_id      = data.aws_ami.runner.id


### PR DESCRIPTION
Currently, if `market_options` is set to `null`, then Terraform will continuously detect a diff for the launch template configuration and recreate it. This change will use a `dynamic` block to exclude the  `instance_market_options` block entirely if `market_options` is set to `null`.

Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>