### PR TITLE
Support af-south-1 region

### DIFF
--- a/modules/runners/templates/install-config-runner.sh
+++ b/modules/runners/templates/install-config-runner.sh
@@ -1,14 +1,16 @@
 cd /home/$USER_NAME
 mkdir actions-runner && cd actions-runner
 
-aws s3 cp ${s3_location_runner_distribution} actions-runner.tar.gz
+REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+
+aws s3 cp ${s3_location_runner_distribution} actions-runner.tar.gz --region $REGION
 tar xzf ./actions-runner.tar.gz
 rm -rf actions-runner.tar.gz
 
 ${arm_patch}
 
 INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
-REGION=$(curl -s 169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+
 
 echo wait for configuration
 while [[ $(aws ssm get-parameters --names ${environment}-$INSTANCE_ID --with-decryption --region $REGION | jq -r ".Parameters | .[0] | .Value") == null ]]; do


### PR DESCRIPTION
Agents stall when running in af-south-1 unless the region is set explicitly: 
```
aws s3 cp s3://default-dist-xxxxx1245/actions-runner-linux.tar.gz .
download failed: s3://default-dist-xxxxx1245/actions-runner-linux.tar.gz to ./actions-runner-linux.tar.gz An error occurred (IllegalLocationConstraintException) when calling the GetObject operation: The af-south-1 location constraint is incompatible for the region specific endpoint this request was sent to.


[root@ip-10-165-0-77 bin]# aws s3 cp s3://default-dist-xxxxx1245/actions-runner-linux.tar.gz . --region af-south-1
download: s3://default-dist-xxxxx1245/actions-runner-linux.tar.gz to ./actions-runner-linux.tar.gz
```