### PR TITLE
Add ability to specify custom location

### DIFF
--- a/modules/download-lambda/main.tf
+++ b/modules/download-lambda/main.tf
@@ -2,7 +2,7 @@ resource "null_resource" "download" {
   count = length(var.lambdas)
 
   triggers = {
-    name = var.lambdas[count.index].name
+    name = basename(var.lambdas[count.index].name)
     file = "${var.lambdas[count.index].name}.zip"
     tag  = var.lambdas[count.index].tag
   }


### PR DESCRIPTION
Now you can specify the `name` as the absolute/relative path to the file you want to save

Example:
```
module "lambdas" {
  source = "<source location>"
  lambdas = [
    {
      name = "../../my_lambda_archives_location/webhook"
      tag  = "v0.11.0"
    },
    {
      name = "/home/user/another/location/runners"
      tag  = "v0.11.0"
    },
    {
      name = "runner-binaries-syncer"
      tag  = "v0.11.0"
    }
  ]
}
```

The better approach I can propose is to provide a third parameter per lambda like `location which is empty by default. If specified, then store the file in the specified location/file

Like:
```
module "lambdas" {
  source = "<source location>"
  lambdas = [
    {
      location = "../../my_lambda_archives_location/webhook.zip"  # can support the location as folder, but require more work
      name     = "webhook"
      tag      = "v0.11.0"
    }
  ]
}
```