### PR TITLE
Add ingress rules for runner SG

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -133,6 +133,23 @@ resource "aws_security_group" "runner_sg" {
 
   vpc_id = var.vpc_id
 
+  dynamic "ingress" {
+    for_each = var.ingress_rules
+    iterator = each
+
+    content {
+      cidr_blocks      = each.value.cidr_blocks
+      ipv6_cidr_blocks = each.value.ipv6_cidr_blocks
+      prefix_list_ids  = each.value.prefix_list_ids
+      from_port        = each.value.from_port
+      protocol         = each.value.protocol
+      security_groups  = each.value.security_groups
+      self             = each.value.self
+      to_port          = each.value.to_port
+      description      = each.value.description
+    }
+  }
+
   dynamic "egress" {
     for_each = var.egress_rules
     iterator = each

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -370,3 +370,19 @@ variable "egress_rules" {
     description      = null
   }]
 }
+
+variable "ingress_rules" {
+  description = "List of ingress rules for the GitHub runner instances."
+  type = list(object({
+    cidr_blocks      = list(string)
+    ipv6_cidr_blocks = list(string)
+    prefix_list_ids  = list(string)
+    from_port        = number
+    protocol         = string
+    security_groups  = list(string)
+    self             = bool
+    to_port          = number
+    description      = string
+  }))
+  default = []
+}


### PR DESCRIPTION
We are using bastion in our setup to access all instances. SSM is not convenient for us.
As now we are using `key_name` to have the SSH key propagated, we would also like to have SSH access to the node without additional manual work.

To achieve this we should be able to add SSH access from special SG, instance_ip, or subnet. This PR is adding the ability to specify `ingress` for Runner SG.

P.S. Currently you can add any rules to `ingress` manually and Terraform will not show changes. But it is not good as the infrastructure is not in the code now...

Another solution would be to add SG id to the output and let a user add SG rules manually and attach them to the group. But in this case, we will have 2 different approaches for `egress` and `ingress`, which is not good, IMHO.