### PR TITLE
Reflect KMS changes from 0.16.0 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,7 @@ resource "aws_kms_key" "github" {
 module "runners" {
 
   ...
-  manage_kms_key = false
-  kms_key_id     = aws_kms_key.github.key_id
+  kms_key_arn = aws_kms_key.github.arn
   ...
 
 ```


### PR DESCRIPTION
With version 0.16.0:
> When using a CMK by setting the variable kms_key_id, a small update is
> required. Replace this variable by the ARN of the CMK by setting
> kms_key_arn.