### PR TITLE
Remove Environment tag from IAM Roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,7 +45,7 @@ module "webhook" {
 
   aws_region  = var.aws_region
   environment = var.environment
-  tags        = local.tags
+  tags        = var.tags
   kms_key_arn = var.kms_key_arn
 
   sqs_build_queue               = aws_sqs_queue.queued_builds
@@ -72,7 +72,7 @@ module "runners" {
   vpc_id      = var.vpc_id
   subnet_ids  = var.subnet_ids
   environment = var.environment
-  tags        = local.tags
+  tags        = var.tags
 
   s3_bucket_runner_binaries   = module.runner_binaries.bucket
   s3_location_runner_binaries = local.s3_action_runner_url
@@ -138,7 +138,7 @@ module "runner_binaries" {
 
   aws_region  = var.aws_region
   environment = var.environment
-  tags        = local.tags
+  tags        = var.tags
 
   distribution_bucket_name = "${var.environment}-dist-${random_string.random.result}"
 

--- a/modules/runners/policies-runner.tf
+++ b/modules/runners/policies-runner.tf
@@ -5,7 +5,7 @@ resource "aws_iam_role" "runner" {
   assume_role_policy   = templatefile("${path.module}/policies/instance-role-trust-policy.json", {})
   path                 = local.role_path
   permissions_boundary = var.role_permissions_boundary
-  tags                 = local.tags
+  tags                 = var.tags
 }
 
 resource "aws_iam_instance_profile" "runner" {

--- a/modules/runners/scale-down.tf
+++ b/modules/runners/scale-down.tf
@@ -63,7 +63,7 @@ resource "aws_iam_role" "scale_down" {
   assume_role_policy   = data.aws_iam_policy_document.lambda_assume_role_policy.json
   path                 = local.role_path
   permissions_boundary = var.role_permissions_boundary
-  tags                 = local.tags
+  tags                 = var.tags
 }
 
 resource "aws_iam_role_policy" "scale_down" {

--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -61,7 +61,7 @@ resource "aws_iam_role" "scale_up" {
   assume_role_policy   = data.aws_iam_policy_document.lambda_assume_role_policy.json
   path                 = local.role_path
   permissions_boundary = var.role_permissions_boundary
-  tags                 = local.tags
+  tags                 = var.tags
 }
 
 resource "aws_iam_role_policy" "scale_up" {


### PR DESCRIPTION
Following discussion on #1328 which would break the module's functionality, this PR takes a different approach to the issue I described in #1280.

## Problem Summary
Using `var.environment` to tag all resources with a key named `Environment` is incompatible with some organization's
tagging policies. This is due to IAM Roles being case insensitive to tags, where an orgnaization is using an `environment` tag for all resources, the Roles cannot be created.

## Behaviour
When deploying to our stack, where we include an `environment` tag on all resources, we encounter this problem on the IAM Roles created for each Lambda:

```
Error: Error creating IAM Role test-runner-action-webhook-lambda-role: InvalidInput: Duplicate tag keys found. Please note that Tag keys are case insensitive.
│ 	status code: 400, request id: 3ac70edf-d44a-4410-ada8-41c786a1593b
│
│   with module.test-github-runner.module.webhook.aws_iam_role.webhook_lambda,
│   on .terraform/modules/test-github-runner/modules/webhook/webhook.tf line 51, in resource "aws_iam_role" "webhook_lambda":
│   51: resource "aws_iam_role" "webhook_lambda" {
```

## Proposed solution 
Stop tagging IAM Roles with `Environment` value, this tag isn't required on IAM Roles to maintain the functionality of this module.