### PR TITLE
feat: adding message retention seconds

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ resource "aws_sqs_queue" "queued_builds" {
   name                        = "${var.environment}-queued-builds.fifo"
   delay_seconds               = var.delay_webhook_event
   visibility_timeout_seconds  = var.runners_scale_up_lambda_timeout
+  message_retention_seconds   = var.job_queue_retention_in_seconds
   fifo_queue                  = true
   receive_wait_time_seconds   = 10
   content_based_deduplication = true

--- a/variables.tf
+++ b/variables.tf
@@ -370,7 +370,11 @@ variable "delay_webhook_event" {
   type        = number
   default     = 30
 }
-
+variable "job_queue_retention_in_seconds" {
+  description = "The number of seconds the job is held in the queue before it is purged"
+  type        = number
+  default     = 86400
+}
 variable "runner_egress_rules" {
   description = "List of egress rules for the GitHub runner instances."
   type = list(object({


### PR DESCRIPTION
Fixes #953

Set the default to 1 day because jobs can be queued for 24 hours then are cancelled by github.