### PR TITLE
feat: support single line private keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ resource "aws_iam_service_linked_role" "spot" {
 
 Next create a second terraform workspace and initiate the module, or adapt one of the [examples](./examples).
 
-Note that `github_app.key_base64` needs to be a base64 string of the `.pem` key i.e. the output of `base64 app.private-key.pem`. The decoded string can either be a multiline value or a single line value with new lines represented with literal `\n` characters.
+Note that `github_app.key_base64` needs to be a base64-encoded string of the `.pem` file i.e. the output of `base64 app.private-key.pem`. The decoded string can either be a multiline value or a single line value with new lines represented with literal `\n` characters.
 
 ```terraform
 module "github-runner" {

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ resource "aws_iam_service_linked_role" "spot" {
 
 Next create a second terraform workspace and initiate the module, or adapt one of the [examples](./examples).
 
-Note that the key needs to be provided as a base64 string i.e. the output of `base64 app.private-key.pem`. The decoded string can either be a multiline value or a single line value with new lines represented with literal `\n` characters.
+Note that `github_app.key_base64` needs to be a base64 string of the `.pem` key i.e. the output of `base64 app.private-key.pem`. The decoded string can either be a multiline value or a single line value with new lines represented with literal `\n` characters.
 
 ```terraform
 module "github-runner" {

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ resource "aws_iam_service_linked_role" "spot" {
 
 Next create a second terraform workspace and initiate the module, or adapt one of the [examples](./examples).
 
-Note : The key needs to be provided as a base64 string i.e. the output of `base64 app.private-key.pem`. The decoded string can either be a multiline value or a single line value with new lines represented with literal `\n` characters.
+Note that the key needs to be provided as a base64 string i.e. the output of `base64 app.private-key.pem`. The decoded string can either be a multiline value or a single line value with new lines represented with literal `\n` characters.
 
 ```terraform
 module "github-runner" {

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ resource "aws_iam_service_linked_role" "spot" {
 
 Next create a second terraform workspace and initiate the module, or adapt one of the [examples](./examples).
 
-Note that `github_app.key_base64` needs to be the base64-encoded `.pem` file, i.e., the output of `base64 app.private-key.pem` (not directly the content of `app.private-key.pem`).
+Note : The key needs to be provided as a base64 string i.e. the output of `base64 app.private-key.pem`. The decoded string can either be a multiline value or a single line value with new lines represented with literal `\n` characters.
 
 ```terraform
 module "github-runner" {

--- a/modules/runners/lambdas/runners/src/scale-runners/gh-auth.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/gh-auth.ts
@@ -48,10 +48,12 @@ async function createAuth(installationId: number | undefined, ghesApiUrl: string
     privateKey: Buffer.from(
       await getParameterValue(process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME),
       'base64',
-    // replace literal \n characters with new lines to allow the key to be stored as a 
-    // single line variable. This logic should match how the GitHub Terraform provider 
-    // processes private keys to retain compatibility between the projects
-    ).toString().replace('/[\\n]/g', String.fromCharCode(13)),
+      // replace literal \n characters with new lines to allow the key to be stored as a
+      // single line variable. This logic should match how the GitHub Terraform provider
+      // processes private keys to retain compatibility between the projects
+    )
+      .toString()
+      .replace('/[\\n]/g', String.fromCharCode(13)),
   };
   if (installationId) authOptions = { ...authOptions, installationId };
 

--- a/modules/runners/lambdas/runners/src/scale-runners/gh-auth.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/gh-auth.ts
@@ -48,7 +48,10 @@ async function createAuth(installationId: number | undefined, ghesApiUrl: string
     privateKey: Buffer.from(
       await getParameterValue(process.env.PARAMETER_GITHUB_APP_KEY_BASE64_NAME),
       'base64',
-    ).toString(),
+    // replace literal \n characters with new lines to allow the key to be stored as a 
+    // single line variable. This logic should match how the GitHub Terraform provider 
+    // processes private keys to retain compatibility between the projects
+    ).toString().replace("/[\\n]/g", String.fromCharCode(13)),
   };
   if (installationId) authOptions = { ...authOptions, installationId };
 

--- a/modules/runners/lambdas/runners/src/scale-runners/gh-auth.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/gh-auth.ts
@@ -51,7 +51,7 @@ async function createAuth(installationId: number | undefined, ghesApiUrl: string
     // replace literal \n characters with new lines to allow the key to be stored as a 
     // single line variable. This logic should match how the GitHub Terraform provider 
     // processes private keys to retain compatibility between the projects
-    ).toString().replace("/[\\n]/g", String.fromCharCode(13)),
+    ).toString().replace('/[\\n]/g', String.fromCharCode(13)),
   };
   if (installationId) authOptions = { ...authOptions, installationId };
 

--- a/modules/runners/lambdas/runners/src/scale-runners/gh-auth.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/gh-auth.ts
@@ -53,7 +53,7 @@ async function createAuth(installationId: number | undefined, ghesApiUrl: string
       // processes private keys to retain compatibility between the projects
     )
       .toString()
-      .replace('/[\\n]/g', String.fromCharCode(13)),
+      .replace('/[\\n]/g', String.fromCharCode(10)),
   };
   if (installationId) authOptions = { ...authOptions, installationId };
 


### PR DESCRIPTION
Fixes: https://github.com/philips-labs/terraform-aws-github-runner/issues/1341

Replace literal `\n` chars with new lines so once the base64 string is decoded the value can a single line string or a multiline string

**Rationale**

1. Single line variables are easier to deal with in GitHub Actions in multiple ways
2. As pointed out in the issue this logic is being applied to the Terraform GitHub provider and so it would be cool if the 2 projects aligned given they are a natural fit

Regex tested against Javascript in https://regex101.com/

EDIT I need to deploy this on my end to check it works as expected as I am not familiar with Typescript unless you can see it will work as is.