### PR TITLE
fix: clean up non used variables in examples

### DIFF
--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -2,7 +2,3 @@
 variable "github_app_key_base64" {}
 
 variable "github_app_id" {}
-
-variable "github_app_client_id" {}
-
-variable "github_app_client_secret" {}

--- a/examples/ubuntu/variables.tf
+++ b/examples/ubuntu/variables.tf
@@ -2,7 +2,3 @@
 variable "github_app_key_base64" {}
 
 variable "github_app_id" {}
-
-variable "github_app_client_id" {}
-
-variable "github_app_client_secret" {}


### PR DESCRIPTION
Clean up unused variables in examples to avoid the examples are not working.