### PR TITLE
chore: Ensure mockes are always loaded so tests can run in isolation

### DIFF
--- a/.github/workflows/lambda-runners.yml
+++ b/.github/workflows/lambda-runners.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn test
       - name: Run two tests in isolation
         run: |
-           yarn run test src/scale-runners/scale-up.test.ts -t 'scaleUp with GHES on org level creates a runner with labels in s specific group'
-           yarn run test src/scale-runners/scale-up.test.ts -t 'scaleUp with public GH on org level creates a runner with labels in s specific group'
+           yarn run test src/scale-runners/scale-up.test.ts -t 'scaleUp with GHES on org level creates a runner with labels in s specific group' --coverage=false
+           yarn run test src/scale-runners/scale-up.test.ts -t "scaleUp with public GH on org level creates a runner with labels in s specific group' --coverage=false
       - name: Build distribution
         run: yarn build

--- a/.github/workflows/lambda-runners.yml
+++ b/.github/workflows/lambda-runners.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Run two tests in isolation
         run: |
            yarn run test src/scale-runners/scale-up.test.ts -t 'scaleUp with GHES on org level creates a runner with labels in s specific group' --coverage=false
-           yarn run test src/scale-runners/scale-up.test.ts -t "scaleUp with public GH on org level creates a runner with labels in s specific group' --coverage=false
+           yarn run test src/scale-runners/scale-up.test.ts -t 'scaleUp with public GH on org level creates a runner with labels in s specific group' --coverage=false
       - name: Build distribution
         run: yarn build

--- a/.github/workflows/lambda-runners.yml
+++ b/.github/workflows/lambda-runners.yml
@@ -26,5 +26,9 @@ jobs:
         run: yarn lint
       - name: Run tests
         run: yarn test
+      - name: Run two tests in isolation
+        run: |
+           yarn run test src/scale-runners/scale-up.test.ts -t 'scaleUp with GHES on org level creates a runner with labels in s specific group'
+           yarn run test src/scale-runners/scale-up.test.ts -t 'scaleUp with public GH on org level creates a runner with labels in s specific group'
       - name: Build distribution
         run: yarn build

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -112,28 +112,28 @@ beforeEach(() => {
       owner: TEST_DATA.repositoryOwner,
     },
   ]);
+
+  mockedAppAuth.mockResolvedValue({
+    type: 'app',
+    token: 'token',
+    appId: TEST_DATA.installationId,
+    expiresAt: 'some-date',
+  });
+  mockedInstallationAuth.mockResolvedValue({
+    type: 'token',
+    tokenType: 'installation',
+    token: 'token',
+    createdAt: 'some-date',
+    expiresAt: 'some-date',
+    permissions: {},
+    repositorySelection: 'all',
+  });
+
+  mockCreateClient.mockResolvedValue(new mocktokit());
 });
 
 describe('scaleUp with GHES', () => {
   beforeEach(() => {
-    mockedAppAuth.mockResolvedValue({
-      type: 'app',
-      token: 'token',
-      appId: TEST_DATA.installationId,
-      expiresAt: 'some-date',
-    });
-    mockedInstallationAuth.mockResolvedValue({
-      type: 'token',
-      tokenType: 'installation',
-      token: 'token',
-      createdAt: 'some-date',
-      expiresAt: 'some-date',
-      permissions: {},
-      repositorySelection: 'all',
-    });
-
-    mockCreateClient.mockResolvedValue(new mocktokit());
-
     process.env.GHES_URL = 'https://github.enterprise.something';
   });
 
@@ -360,6 +360,8 @@ describe('scaleUp with GHES', () => {
 });
 
 describe('scaleUp with public GH', () => {
+  beforeEach(() => {});
+
   it('ignores non-sqs events', async () => {
     expect.assertions(1);
     expect(scaleUpModule.scaleUp('aws:s3', TEST_DATA)).rejects.toEqual(Error('Cannot handle non-SQS events!'));

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-up.test.ts
@@ -360,8 +360,6 @@ describe('scaleUp with GHES', () => {
 });
 
 describe('scaleUp with public GH', () => {
-  beforeEach(() => {});
-
   it('ignores non-sqs events', async () => {
     expect.assertions(1);
     expect(scaleUpModule.scaleUp('aws:s3', TEST_DATA)).rejects.toEqual(Error('Cannot handle non-SQS events!'));


### PR DESCRIPTION
## Problem
Test set for GH public in module runners, `src/scale-runners/scale-up.test.ts` cannot run in isolation. As full test suite all tests are PASSING, running a test in isolation for the set GH Public results in failures. In CI we run the full set.

## Solution
Problem is that several mocks are only loaded for GHES cases, which are loaded first. Moving the mockes one level up (suite level), ensures mocks are loaded always. 