### PR TITLE
fix install_config_runner -> install_runner

### DIFF
--- a/examples/ubuntu/templates/user-data.sh
+++ b/examples/ubuntu/templates/user-data.sh
@@ -59,7 +59,7 @@ echo export PATH=/home/$USER_NAME/bin:$PATH >>/home/$USER_NAME/.profile
 loginctl enable-linger $USER_NAME
 su -l $USER_NAME -c "systemctl --user enable docker"
 
-${install_config_runner}
+${install_runner}
 
 # config runner for rootless docker
 cd /home/$USER_NAME/actions-runner/

--- a/examples/ubuntu/templates/user-data.sh
+++ b/examples/ubuntu/templates/user-data.sh
@@ -68,4 +68,4 @@ echo PATH=/home/$USER_NAME/bin:$PATH >>.env
 
 ${post_install}
 
-./svc.sh start
+${start_runner}


### PR DESCRIPTION
https://github.com/philips-labs/terraform-aws-github-runner/commit/060daac3568cd36f8b203d3f77f736df7aefb223#diff-e9624b388e62ca51cf1fe073eb0919588e8c36a1143ecdb49580996a89f13beb

https://github.com/philips-labs/terraform-aws-github-runner/commit/060daac3568cd36f8b203d3f77f736df7aefb223#r61361220

I believe this was forgotten to be changed in ubuntu example

Afrer upgrading I got for the ubuntu userdata.sh this:
```
│ Invalid value for "vars" parameter: vars map does not contain key "install_config_runner", referenced at ./templates/user-data.sh.tpl:74,3-24.
╵
```

