### PR TITLE
docs: Offline runners are not required anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,26 +105,6 @@ Examples are provided in [the example directory](examples/). Please ensure you h
 
 The module supports two main scenarios for creating runners. On repository level a runner will be dedicated to only one repository, no other repository can use the runner. On organization level you can use the runner(s) for all the repositories within the organization. See [GitHub instructions](https://help.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners) for more information. Before starting the deployment you have to choose one option.
 
-GitHub workflows fail immediately if there is no action runner available for your builds. Since this module supports scaling down to zero, builds will fail in case there is no active runner available. We recommend to create an offline runner with matching labels to the configuration. Create this runner manually by following the [GitHub instructions](https://help.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners) for adding a new runner on your local machine. If you stop the process after the step of running the `config.sh` script the runner will remain offline. This offline runner ensures that builds will not fail immediately and stay queued until there is an EC2 runner to pick it up.
-
-Another convenient way of deploying this temporary required runner is using following approach. This automates all the manual labor.
-
-<details>
-  <summary>Temporary runner using Docker</summary>
-
-  ```bash
-  docker run -it --name my-runner \
-      -e RUNNER_LABELS=selfhosted,Linux,Ubuntu -e RUNNER_NAME=my-repo-docker-runner \
-      -e GITHUB_ACCESS_TOKEN=$GH_PERSONAL_ACCESS_TOKEN \
-      -e RUNNER_REPOSITORY_URL=https://github.com/my-org/my-repo \
-      -v /var/run/docker.sock:/var/run/docker.sock \
-      tcardonne/github-runner:ubuntu-20.04
-  ```
-
-</details>
-
-You should stop and remove the container once the runner is registered as the builds would otherwise go to your local Docker container.
-
 The setup consists of running Terraform to create all AWS resources and manually configuring the GitHub App. The Terraform module requires configuration from the GitHub App and the GitHub app requires output from Terraform. Therefore you first create the GitHub App and configure the basics, then run Terraform, and afterwards finalize the configuration of the GitHub App.
 
 ### Setup GitHub App (part 1)
@@ -244,8 +224,6 @@ Finally you need to ensure the app is installed to all or selected repositories.
 Go back to the GitHub App and update the following settings.
 
 1. In the "Install App" section, install the App in your organization, either in all or in selected repositories.
-
-You are now ready to run action workloads on self hosted runner. Remember that builds will fail if there is no (offline) runner available with matching labels.
 
 ### Encryption
 


### PR DESCRIPTION
Prevous jobs for self-hosted runners failing immediatly if no potential runner was available. This is changed, jobs will kept queued for 24 hours. This removed the need to create first an offline runner to allow scaling back to zero. (https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow)
