### PR TITLE
feat(packer): add vars and minor clean up

### DIFF
--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -38,7 +38,7 @@ variable "instance_type" {
 }
 
 variable "root_volume_size_gb" {
-  type = number
+  type    = number
   default = 8
 }
 

--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -7,10 +7,10 @@ packer {
   }
 }
 
-variable "action_runner_url" {
-  description = "The URL to the tarball of the action runner"
+variable "runner_version" {
+  description = "The version (no v prefix) of the runner software to install https://github.com/actions/runner/releases"
   type        = string
-  default     = "https://github.com/actions/runner/releases/download/v2.284.0/actions-runner-linux-x64-2.284.0.tar.gz"
+  default     = "2.286.0"
 }
 
 variable "region" {
@@ -19,10 +19,17 @@ variable "region" {
   default     = "eu-west-1"
 }
 
+variable "security_group_id" {
+  description = "The id of the security group to allow access to the packer builder"
+  type        = string
+  default     = null
+}
+
 source "amazon-ebs" "githubrunner" {
-  ami_name      = "github-runner-amzn2-x86_64-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  instance_type = "m3.medium"
-  region        = var.region
+  ami_name          = "github-runner-amzn2-x86_64-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  instance_type     = "m3.medium"
+  region            = var.region
+  security_group_id = var.security_group_id
   source_ami_filter {
     filters = {
       name                = "amzn2-ami-hvm-2.*-x86_64-ebs"
@@ -60,7 +67,7 @@ build {
 
   provisioner "shell" {
     environment_vars = [
-      "RUNNER_TARBALL_URL=${var.action_runner_url}"
+      "RUNNER_TARBALL_URL=https://github.com/actions/runner/releases/download/v${var.runner_version}/actions-runner-linux-x64-${var.runner_version}.tar.gz"
     ]
     inline = [templatefile("../install-runner.sh", {
       install_runner = templatefile("../../modules/runners/templates/install-runner.sh", {

--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -37,10 +37,15 @@ variable "instance_type" {
   default     = "m3.medium"
 }
 
+variable "root_volume_size_gb" {
+  type = number
+  default = 8
+}
+
 variable "tags" {
   description = "Additional tags to add globally"
   type        = map(string)
-    default     = {}
+  default     = {}
 }
 
 source "amazon-ebs" "githubrunner" {
@@ -66,6 +71,12 @@ source "amazon-ebs" "githubrunner" {
       Release       = "Latest"
       Base_AMI_Name = "{{ .SourceAMIName }}"
   })
+
+  launch_block_device_mappings {
+    device_name = "/dev/xvda"
+    volume_size = "${var.root_volume_size_gb}"
+    volume_type = "gp3"
+  }
 }
 
 build {

--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -42,7 +42,7 @@ source "amazon-ebs" "githubrunner" {
   instance_type     = var.instance_type
   region            = var.region
   security_group_id = var.security_group_id
-  subnet_id = var.subnet_id
+  subnet_id         = var.subnet_id
   source_ami_filter {
     filters = {
       name                = "amzn2-ami-hvm-2.*-x86_64-ebs"

--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -20,16 +20,29 @@ variable "region" {
 }
 
 variable "security_group_id" {
-  description = "The id of the security group to allow access to the packer builder"
+  description = "The ID of the security group Packer will associate with the builder to enable access"
   type        = string
   default     = null
 }
 
+variable "subnet_id" {
+  description = "If using VPC, the ID of the subnet, such as subnet-12345def, where Packer will launch the EC2 instance. This field is required if you are using an non-default VPC"
+  type        = string
+  default     = null
+}
+
+variable "instance_type" {
+  description = "The instance type Packer will use for the builder"
+  type        = string
+  default     = "m3.medium"
+}
+
 source "amazon-ebs" "githubrunner" {
   ami_name          = "github-runner-amzn2-x86_64-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  instance_type     = "m3.medium"
+  instance_type     = var.instance_type
   region            = var.region
   security_group_id = var.security_group_id
+  subnet_id = var.subnet_id
   source_ami_filter {
     filters = {
       name                = "amzn2-ami-hvm-2.*-x86_64-ebs"

--- a/modules/runners/templates/install-runner.sh
+++ b/modules/runners/templates/install-runner.sh
@@ -13,7 +13,7 @@ file_name="actions-runner.tar.gz"
 
 echo "Creating actions-runner directory for the GH Action installtion"
 cd /opt/
-mkdir actions-runner && cd actions-runner
+sudo mkdir actions-runner && sudo chown -R "$(whoami)" actions-runner && cd actions-runner
 
 if [[ -n "$RUNNER_TARBALL_URL" ]]; then
   echo "Downloading the GH Action runner from $RUNNER_TARBALL_URL to $file_name"

--- a/modules/runners/templates/install-runner.sh
+++ b/modules/runners/templates/install-runner.sh
@@ -13,7 +13,7 @@ file_name="actions-runner.tar.gz"
 
 echo "Creating actions-runner directory for the GH Action installtion"
 cd /opt/
-sudo mkdir actions-runner && sudo chown -R "$(whoami)" actions-runner && cd actions-runner
+mkdir -p actions-runner && cd actions-runner
 
 if [[ -n "$RUNNER_TARBALL_URL" ]]; then
   echo "Downloading the GH Action runner from $RUNNER_TARBALL_URL to $file_name"


### PR DESCRIPTION
👋 , I wish to use your packer hcl however it needs more variables to be usable in my env:

1. SGs that are open to 0.0.0.0/0 are a big no no so I added a var to allow the SG to be passed in allowing for a more restrictive SG to be created up front. If no SG var is set then null results in the default behaviour of creating a temp SG (as happens now). Added additional vars needed for placing the builder and setting the instance type.
2. Seperated the version from the url for better readability and to perhaps allow for this to be bumped by renovate automatically later.
3. Fixed the permission denied errors raised in https://github.com/philips-labs/terraform-aws-github-runner/issues/1610. /opt and everything in it are owned by root root and so mkdir won't work without sudo and then a subsequent ownership change for the curl.

EDIT in draft mode as I need to try it with a pre-made SG first