### PR TITLE
chore(docs): refer to dedicate channel for the runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,6 @@ This module is part of the Philips Forest.
 
 ```
 
-Talk to the forestkeepers in the `forest`-channel on Slack.
+Talk to the forestkeepers in the `runners`-channel on Slack.
 
 [![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/philips-software/shared_invite/zt-xecw65v5-i1531hGP~mdVwgxLFx7ckg)


### PR DESCRIPTION
Refer to a dedicated channel for the runners