### PR TITLE
fix(runnrs): Pool runners to allow multiple event rules and targets

### DIFF
--- a/modules/runners/pool/main.tf
+++ b/modules/runners/pool/main.tf
@@ -99,7 +99,7 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
 resource "aws_cloudwatch_event_rule" "pool" {
   count = length(var.config.pool)
 
-  name                = "${var.config.environment}-${[count.index]}-pool-rule"
+  name                = "${var.config.environment}-pool-${count.index}-rule"
   schedule_expression = var.config.pool[count.index].schedule_expression
   tags                = var.config.tags
 }

--- a/modules/runners/pool/main.tf
+++ b/modules/runners/pool/main.tf
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_event_target" "pool" {
 resource "aws_lambda_permission" "pool" {
   count = length(var.config.pool)
 
-  statement_id  = "AllowExecutionFromCloudWatch"
+  statement_id  = "AllowExecutionFromCloudWatch-${count.index}"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.pool.function_name
   principal     = "events.amazonaws.com"

--- a/modules/runners/pool/main.tf
+++ b/modules/runners/pool/main.tf
@@ -99,7 +99,7 @@ data "aws_iam_policy_document" "lambda_assume_role_policy" {
 resource "aws_cloudwatch_event_rule" "pool" {
   count = length(var.config.pool)
 
-  name                = "${var.config.environment}-pool-rule"
+  name                = "${var.config.environment}-${[count.index]}-pool-rule"
   schedule_expression = var.config.pool[count.index].schedule_expression
   tags                = var.config.tags
 }


### PR DESCRIPTION
if the pool list has more than 1 element, terraform cannot apply

It will throw errors like
```sh
Error: Error adding new Lambda Permission for github-pool: ResourceConflictException: The statement id (AllowExecutionFromCloudWatch) provided already exists. Please provide a new statement id, or remove the existing statement.
{
  RespMetadata: {
    StatusCode: 409,
    RequestID: "1baaaa63-a167-49a1-9eb4-e07f824a85ce"
  },
  Message_: "The statement id (AllowExecutionFromCloudWatch) provided already exists. Please provide a new statement id, or remove the existing statement.",
  Type: "User"
```