### PR TITLE
fix(examples): Update AMI filter

### DIFF
--- a/examples/ephemeral/main.tf
+++ b/examples/ephemeral/main.tf
@@ -66,7 +66,7 @@ module "runners" {
 
   # configure your pre-built AMI
   # enabled_userdata = false
-  # ami_filter       = { name = ["github-runner-amzn2-x86_64-2021*"] }
+  # ami_filter       = { name = ["github-runner-amzn2-x86_64-*"] }
   # ami_owners       = [data.aws_caller_identity.current.account_id]
 
   # Enable logging

--- a/examples/prebuilt/variables.tf
+++ b/examples/prebuilt/variables.tf
@@ -10,7 +10,7 @@ variable "runner_os" {
 
 variable "ami_name_filter" {
   type    = string
-  default = "github-runner-amzn2-x86_64-2021*"
+  default = "github-runner-amzn2-x86_64-*"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
- Updated AMI filter to select the latest instead of the latest in 2012
- Add commented examples for AMI and ephemeral to ubuntu example