### PR TITLE
feat: Variablize delete_on_termination

### DIFF
--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -42,6 +42,12 @@ variable "root_volume_size_gb" {
   default = 8
 }
 
+variable "ebs_delete_on_termination" {
+  description = "Indicates whether the EBS volume is deleted on instance termination."
+  type        = bool
+  default     = true
+}
+
 variable "global_tags" {
   description = "Tags to apply to everything"
   type        = map(string)
@@ -91,9 +97,10 @@ source "amazon-ebs" "githubrunner" {
 
 
   launch_block_device_mappings {
-    device_name = "/dev/xvda"
-    volume_size = "${var.root_volume_size_gb}"
-    volume_type = "gp3"
+    device_name           = "/dev/xvda"
+    volume_size           = "${var.root_volume_size_gb}"
+    volume_type           = "gp3"
+    delete_on_termination = "${var.ebs_delete_on_termination}"
   }
 }
 

--- a/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
@@ -42,6 +42,12 @@ variable "root_volume_size_gb" {
   default = 8
 }
 
+variable "ebs_delete_on_termination" {
+  description = "Indicates whether the EBS volume is deleted on instance termination."
+  type        = bool
+  default     = true
+}
+
 variable "global_tags" {
   description = "Tags to apply to everything"
   type        = map(string)
@@ -90,9 +96,10 @@ source "amazon-ebs" "githubrunner" {
   )
 
   launch_block_device_mappings {
-    device_name = "/dev/sda1"
-    volume_size = "${var.root_volume_size_gb}"
-    volume_type = "gp3"
+    device_name           = "/dev/sda1"
+    volume_size           = "${var.root_volume_size_gb}"
+    volume_type           = "gp3"
+    delete_on_termination = "${var.ebs_delete_on_termination}"
   }
 }
 

--- a/images/windows-core-2019/github_agent.windows.pkr.hcl
+++ b/images/windows-core-2019/github_agent.windows.pkr.hcl
@@ -19,6 +19,12 @@ variable "region" {
   default     = "eu-west-1"
 }
 
+variable "ebs_delete_on_termination" {
+  description = "Indicates whether the EBS volume is deleted on instance termination."
+  type        = bool
+  default     = true
+}
+
 source "amazon-ebs" "githubrunner" {
   ami_name      = "github-runner-windows-core-2019-${formatdate("YYYYMMDDhhmm", timestamp())}"
   communicator  = "winrm"
@@ -43,6 +49,11 @@ source "amazon-ebs" "githubrunner" {
   winrm_port     = 5986
   winrm_use_ssl  = true
   winrm_username = "Administrator"
+
+  launch_block_device_mappings {
+    device_name           = "/dev/sda1"
+    delete_on_termination = "${var.ebs_delete_on_termination}"
+  }
 }
 
 build {


### PR DESCRIPTION
    Issue: #1745
    Variablize delete_on_termination for EBS volume.
    Make default as true (which make more sense to delete volumes
    as they are no longer used by runners).


Fixes: https://github.com/philips-labs/terraform-aws-github-runner/issues/1745

https://www.packer.io/plugins/builders/amazon/ebs#delete_on_termination
By default packer use delete_on_termination set to false.

> [delete_on_termination](https://www.packer.io/plugins/builders/amazon/ebs#delete_on_termination) (bool) - Indicates whether the EBS volume is deleted on instance termination. Default false. NOTE: If this value is not explicitly set to true and volumes are not cleaned up by an alternative method, additional volumes will accumulate after every build.

