### PR TITLE
fix: Doc update ephemeral runners need workflow_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The moment a GitHub action workflow requiring a `self-hosted` runner is triggere
 
 For receiving the `check_run` or `workflow_job` event by the webhook (lambda), a webhook needs to be created in GitHub. The `workflow_job` is the preferred option, and the `check_run` option will be maintained for backward compatibility. The advantage of the `workflow_job` event is that the runner checks if the received event can run on the configured runners by matching the labels, which avoid instances being scaled up and never used. The following options are available:
 
-- `workflow_job`: **(preferred option)** create a webhook on enterprise, org or app level.
+- `workflow_job`: **(preferred option)** create a webhook on enterprise, org or app level. Select this option for ephemeral runners.
 - `check_run`: create a webhook on enterprise, org, repo or app level. When using the app option, the app needs to be installed to repo's are using the self-hosted runners.
 -  a Webhook needs to be created. The webhook hook can be defined on enterprise, org, repo, or app level. 
 


### PR DESCRIPTION
While running ephemeral runners, check_run does not work and it is not mentioned anywhere in documentation.

2022-02-17 08:43:10.319  WARN [scale-runners:5c3d74d9-1321-5f45-81rd-2e51281e7b3f index.js:113840  Runtime.handler] Ignoring error: The event type check_run is not supported in combination with ephemeral runners.Please ensure you have enabled workflow_job events. 
{}