### PR TITLE
fix: Use source_hash instead of etag to prevent drift when using KMS

### DIFF
--- a/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -119,10 +119,10 @@ resource "aws_lambda_permission" "syncer" {
 ###################################################################################
 
 resource "aws_s3_bucket_object" "trigger" {
-  bucket = aws_s3_bucket.action_dist.id
-  key    = "triggers/${aws_lambda_function.syncer.id}-trigger.json"
-  source = "${path.module}/trigger.json"
-  etag   = filemd5("${path.module}/trigger.json")
+  bucket      = aws_s3_bucket.action_dist.id
+  key         = "triggers/${aws_lambda_function.syncer.id}-trigger.json"
+  source      = "${path.module}/trigger.json"
+  source_hash = filemd5("${path.module}/trigger.json")
 
   depends_on = [aws_s3_bucket_notification.on_deploy]
 }


### PR DESCRIPTION
[source_hash](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object#source_hash) - (Optional) Triggers updates like etag but useful to address etag encryption limitations. Set using filemd5("path/to/source") (Terraform 0.11.12 or later). (The value is only stored in state and not saved by AWS.)

source_hash should help eliminate some "plan drifts" that are caused when using KMS encryption and etag together

it shouldn't affect the functionality if not using SSE KMS on the bucket.