### PR TITLE
feat(images): Add associate_public_ip_address variable

### DIFF
--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -31,6 +31,12 @@ variable "subnet_id" {
   default     = null
 }
 
+variable "associate_public_ip_address" {
+  description = "If using a non-default VPC, there is no public IP address assigned to the EC2 instance. If you specified a public subnet, you probably want to set this to true. Otherwise the EC2 instance won't have access to the internet"
+  type        = string
+  default     = null
+}
+
 variable "instance_type" {
   description = "The instance type Packer will use for the builder"
   type        = string
@@ -67,11 +73,12 @@ variable "snapshot_tags" {
 }
 
 source "amazon-ebs" "githubrunner" {
-  ami_name          = "github-runner-amzn2-x86_64-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  instance_type     = var.instance_type
-  region            = var.region
-  security_group_id = var.security_group_id
-  subnet_id         = var.subnet_id
+  ami_name                    = "github-runner-amzn2-x86_64-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  instance_type               = var.instance_type
+  region                      = var.region
+  security_group_id           = var.security_group_id
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = var.associate_public_ip_address
   source_ami_filter {
     filters = {
       name                = "amzn2-ami-hvm-2.*-x86_64-ebs"

--- a/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
@@ -31,6 +31,12 @@ variable "subnet_id" {
   default     = null
 }
 
+variable "associate_public_ip_address" {
+  description = "If using a non-default VPC, there is no public IP address assigned to the EC2 instance. If you specified a public subnet, you probably want to set this to true. Otherwise the EC2 instance won't have access to the internet"
+  type        = string
+  default     = null
+}
+
 variable "instance_type" {
   description = "The instance type Packer will use for the builder"
   type        = string
@@ -67,11 +73,13 @@ variable "snapshot_tags" {
 }
 
 source "amazon-ebs" "githubrunner" {
-  ami_name          = "github-runner-ubuntu-focal-amd64-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  instance_type     = var.instance_type
-  region            = var.region
-  security_group_id = var.security_group_id
-  subnet_id         = var.subnet_id
+  ami_name                    = "github-runner-ubuntu-focal-amd64-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  instance_type               = var.instance_type
+  region                      = var.region
+  security_group_id           = var.security_group_id
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = var.associate_public_ip_address
+
   source_ami_filter {
     filters = {
       name                = "*/ubuntu-focal-20.04-amd64-server-*"


### PR DESCRIPTION
If using a non-default VPC, there is no public IP address assigned to the EC2 instance. If you specified a public subnet, the EC2 instance won't have access to the internet without setting `associate_public_ip_address = true`.