### PR TITLE
fix: Set the minimal AWS provider to 3.50

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 3.50"
     }
   }
 }


### PR DESCRIPTION
See for details #1926 

Set minimal provider to 3.50 to support source_hash for AWS S3 object.