### PR TITLE
feat: Make userdata gzipped in case the user provided userdata is long

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -40,6 +40,8 @@ locals {
 }
 
 data "template_cloudinit_config" "userdata" {
+  count = var.enabled_userdata ? 1 : 0
+
   gzip          = true
   base64_encode = true
   part {

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -142,7 +142,7 @@ resource "aws_launch_template" "runner" {
   }
 
 
-  user_data = var.enabled_userdata ? data.template_cloudinit_config.userdata.rendered : ""
+  user_data = var.enabled_userdata ? data.template_cloudinit_config.userdata[0].rendered : ""
 
   tags = local.tags
 

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -40,7 +40,7 @@ locals {
 }
 
 data "template_cloudinit_config" "userdata" {
-  gzip          = false
+  gzip          = true
   base64_encode = true
   part {
     filename     = "00-init"

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -40,7 +40,7 @@ locals {
 }
 
 data "template_cloudinit_config" "userdata" {
-  gzip          = true
+  gzip          = false
   base64_encode = true
   part {
     filename     = "00-init"


### PR DESCRIPTION
I provide big userdata, `aws_launch_template` bombs out because user_data is simply base64ified and not gzipped, making it larger than 16kb.

This PR should fix that issue. ~I'm testing on my infrastructure now so will let you know if it works :)~

Appears to work fine, though note I am editing out the exec descriptor stuff (#1959) in the fork I'm running on my infrastructure (https://github.com/Makeshift/terraform-aws-github-runner/commit/16d4c04c3f30e9890830eec7e4df6a517ee553f0)