### PR TITLE
fix: Output the role for the pool management

### DIFF
--- a/modules/runners/outputs.tf
+++ b/modules/runners/outputs.tf
@@ -21,3 +21,7 @@ output "lambda_scale_down" {
 output "role_scale_down" {
   value = aws_iam_role.scale_down
 }
+
+output "role_pool" {
+  value = length(var.pool_config) == 0 ? {} : module.pool.role_pool
+}

--- a/modules/runners/pool/outputs.tf
+++ b/modules/runners/pool/outputs.tf
@@ -1,0 +1,3 @@
+output "role_pool" {
+  value = aws_iam_role.pool
+}


### PR DESCRIPTION
Sometimes extra policies need to be attached to roles such as for custom KMS encryption of EBS. We need to output the pool lambda role so it can be configured.