### PR TITLE
fix: outputs for pool need to account for complexity

### DIFF
--- a/modules/runners/outputs.tf
+++ b/modules/runners/outputs.tf
@@ -23,5 +23,5 @@ output "role_scale_down" {
 }
 
 output "role_pool" {
-  value = length(var.pool_config) == 0 ? {} : module.pool.role_pool
+  value = length(var.pool_config) == 0 ? null : module.pool[0].role_pool
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,6 +9,7 @@ output "runners" {
     role_runner             = module.runners.role_runner
     role_scale_up           = module.runners.role_scale_up
     role_scale_down         = module.runners.role_scale_down
+    role_pool               = module.runners.role_pool
   }
 }
 


### PR DESCRIPTION
As the pool is optional the output needs to take this into account and access the first instance in the list. We also must output null if not set.