### PR TITLE
fix: block name should default to `dev/xvda`

### DIFF
--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -56,7 +56,7 @@ variable "block_device_mappings" {
     iops                  = number
   }))
   default = [{
-    device_name           = "/dev/xvd"
+    device_name           = "/dev/xvda"
     delete_on_termination = true
     volume_type           = "gp3"
     volume_size           = 30


### PR DESCRIPTION
This fixes the issue reported on #2017.