### PR TITLE
fix(runner): Don't treat $enable_cloudwatch_agent=="false" as true in Powershell

### DIFF
--- a/modules/runners/templates/start-runner.ps1
+++ b/modules/runners/templates/start-runner.ps1
@@ -30,7 +30,7 @@ Write-Host  "Retrieved /$environment/runner/enable-cloudwatch parameter - ($enab
 $agent_mode=$parameters.where( {$_.Name -eq "/$environment/runner/agent-mode"}).value
 Write-Host  "Retrieved /$environment/runner/agent-mode parameter - ($agent_mode)"
 
-if ($enable_cloudwatch_agent)
+if ($enable_cloudwatch_agent -eq "true")
 {
     Write-Host  "Enabling CloudWatch Agent"    
     & 'C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1' -a fetch-config -m ec2 -s -c "ssm:$environment-cloudwatch_agent_config_runner"


### PR DESCRIPTION
#1737 reported a bug where the userdata script tried to enable the CloudWatch Agent even though it was specified to be disabled. The problem was fixed for `start-runner.sh` in #1738, but the Powershell version has the same bug. This PR fixes the Powershell version.
