### PR TITLE
fix: replaced old environment variable

### DIFF
--- a/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -48,7 +48,7 @@ resource "aws_lambda_function" "syncer" {
 
 resource "aws_iam_role_policy" "lambda_kms" {
   count = try(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.kms_master_key_id, null) != null ? 1 : 0
-  name  = "${var.environment}-lambda-kms-policy-syncer"
+  name  = "${var.prefix}-lambda-kms-policy-syncer"
   role  = aws_iam_role.syncer_lambda.id
 
   policy = templatefile("${path.module}/policies/lambda-kms.json", {


### PR DESCRIPTION
* removed old usage of environment variable which causes an error on template interpolation
<img width="876" alt="Bildschirmfoto 2022-06-13 um 12 44 38" src="https://user-images.githubusercontent.com/9818404/173337221-3eed4d3f-ec9c-4067-a8bb-9ea9ef216277.png">
