### PR TITLE
fix: set kms key on aws_s3_object when encryption is enabled

### DIFF
--- a/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -137,8 +137,8 @@ resource "aws_s3_object" "trigger" {
   bucket     = aws_s3_bucket.action_dist.id
   key        = "triggers/${aws_lambda_function.syncer.id}-trigger.json"
   source     = "${path.module}/trigger.json"
-  etag       = lookup(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default, "kms_master_key_id", null) == null ? filemd5("${path.module}/trigger.json") : null
-  kms_key_id = lookup(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default, "kms_master_key_id", null)
+  etag       = try(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.kms_master_key_id, null) == null ? filemd5("${path.module}/trigger.json") : null
+  kms_key_id = try(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.kms_master_key_id, null)
 
   depends_on = [aws_s3_bucket_notification.on_deploy]
 }

--- a/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -134,10 +134,11 @@ resource "aws_lambda_permission" "syncer" {
 ###################################################################################
 
 resource "aws_s3_object" "trigger" {
-  bucket = aws_s3_bucket.action_dist.id
-  key    = "triggers/${aws_lambda_function.syncer.id}-trigger.json"
-  source = "${path.module}/trigger.json"
-  etag   = filemd5("${path.module}/trigger.json")
+  bucket     = aws_s3_bucket.action_dist.id
+  key        = "triggers/${aws_lambda_function.syncer.id}-trigger.json"
+  source     = "${path.module}/trigger.json"
+  etag       = lookup(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default, "kms_master_key_id", null) == null ? filemd5("${path.module}/trigger.json") : null
+  kms_key_id = lookup(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default, "kms_master_key_id", null)
 
   depends_on = [aws_s3_bucket_notification.on_deploy]
 }


### PR DESCRIPTION
* fixes an error during apply on aws_s3_object when encryption is enabled
* set kms key id when encryption is enabled
* dont set unsupported etag property when encryption is enabled