### PR TITLE
fix: Remove asterik in permission for runner lambda to describe instances

### DIFF
--- a/modules/runners/policies/lambda-scale-down.json
+++ b/modules/runners/policies/lambda-scale-down.json
@@ -4,7 +4,7 @@
         {
             "Effect": "Allow",
             "Action": [
-                "ec2:DescribeInstances*",
+                "ec2:DescribeInstances",
                 "ec2:DescribeTags"
             ],
             "Resource": [


### PR DESCRIPTION
* removed useless asterik in permission (there is no other action with prefix `DescribeInstances`)