### PR TITLE
fix: don't apply extra labels unless defined

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,8 @@ locals {
     id         = module.ssm.parameters.github_app_id
     key_base64 = module.ssm.parameters.github_app_key_base64
   }
+
+  default_runner_labels = "self-hosted,${var.runner_os},${var.runner_architecture}"
 }
 
 resource "random_string" "random" {
@@ -111,7 +113,7 @@ module "webhook" {
 
   # labels
   enable_workflow_job_labels_check = var.runner_enable_workflow_job_labels_check
-  runner_labels                    = "self-hosted,${var.runner_os},${var.runner_architecture},${var.runner_extra_labels}"
+  runner_labels                    = var.runner_extra_labels != "" ? "${local.default_runner_labels},${var.runner_extra_labels}" : local.default_runner_labels
 
   role_path                 = var.role_path
   role_permissions_boundary = var.role_permissions_boundary


### PR DESCRIPTION
Don't apply the value of `var.runner_extra_labels` unless it's set. This prevents the webhook trying to match against a blank label when there are no extra labels defined.

Fixes #1961 