### PR TITLE
feat: Webhook accept jobs where not all labels are provided in job.

### DIFF
--- a/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
@@ -159,7 +159,7 @@ describe('handler', () => {
       expect(sendActionRequest).toBeCalled();
     });
 
-    it('Check webhook does not accept jobs where not all labels are provided in job.', async () => {
+    it('Check webhook accept jobs where not all labels are provided in job.', async () => {
       process.env.RUNNER_LABELS = '["self-hosted", "test", "test2"]';
       process.env.ENABLE_WORKFLOW_JOB_LABELS_CHECK = 'true';
       process.env.WORKFLOW_JOB_LABELS_CHECK_ALL = 'true';
@@ -174,8 +174,8 @@ describe('handler', () => {
         { 'X-Hub-Signature': await webhooks.sign(event), 'X-GitHub-Event': 'workflow_job' },
         event,
       );
-      expect(resp.statusCode).toBe(202);
-      expect(sendActionRequest).not.toBeCalled;
+      expect(resp.statusCode).toBe(201);
+      expect(sendActionRequest).toBeCalled();
     });
 
     it('Check webhook does not accept jobs where not all labels are supported by the runner.', async () => {

--- a/modules/webhook/lambdas/webhook/src/webhook/handler.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.ts
@@ -178,16 +178,9 @@ function isRepoNotAllowed(repoFullName: string, repositoryWhiteList: string[]): 
 
 function canRunJob(job: WorkflowJobEvent, runnerLabels: string[], workflowLabelCheckAll: boolean): boolean {
   const workflowJobLabels = job.workflow_job.labels;
-  let runnerMatch;
-  let jobMatch;
-  if (workflowLabelCheckAll) {
-    runnerMatch = runnerLabels.every((l) => workflowJobLabels.includes(l));
-    jobMatch = workflowJobLabels.every((l) => runnerLabels.includes(l));
-  } else {
-    runnerMatch = runnerLabels.some((l) => workflowJobLabels.includes(l));
-    jobMatch = workflowJobLabels.some((l) => runnerLabels.includes(l));
-  }
-  const match = jobMatch && runnerMatch;
+  const match = workflowLabelCheckAll
+    ? workflowJobLabels.every((l) => runnerLabels.includes(l))
+    : workflowJobLabels.some((l) => runnerLabels.includes(l));
 
   logger.debug(
     `Received workflow job event with labels: '${JSON.stringify(workflowJobLabels)}'. The event does ${


### PR DESCRIPTION
Thanks for this awesome project! It is really useful :)

I think that `webhook` should allow run jobs in `self-hosted` runners without requiring pass all labels.

Labels are usually intended for describing capabilities (in runners) and requirements (in jobs). If I only want to require that my job is run in a `self-hosted` runner no matters what other capabilities runner have, passing only `self-hosted` label should be enough.

On the other hand, if I require to run my job in a `self-hosted` and `ubuntu` runner using these labels, but I haven't any `ubuntu` runner, it shouldn't be run.

Thank you for your time.