### PR TITLE
fix(examples): Upgrading ubuntu example to 22.04

### DIFF
--- a/examples/ubuntu/main.tf
+++ b/examples/ubuntu/main.tf
@@ -46,7 +46,7 @@ module "runners" {
   ami_owners        = ["099720109477"] # Canonical's Amazon account ID
 
   ami_filter = {
-    name = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    name = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
   }
 
   # Custom build AMI, no custom userdata needed.

--- a/examples/ubuntu/templates/user-data.sh
+++ b/examples/ubuntu/templates/user-data.sh
@@ -44,7 +44,7 @@ WantedBy=default.target
 
 EOF
 
-echo export XDG_RUNTIME_DIR=/run/user/$user_id >>/home/$user_name/.profile
+echo export XDG_RUNTIME_DIR=/run/user/$user_id >>/home/$user_name/.bashrc
 
 systemctl daemon-reload
 systemctl enable user@UID.service
@@ -52,8 +52,8 @@ systemctl start user@UID.service
 
 curl -fsSL https://get.docker.com/rootless >>/opt/rootless.sh && chmod 755 /opt/rootless.sh
 su -l $user_name -c /opt/rootless.sh
-echo export DOCKER_HOST=unix:///run/user/$user_id/docker.sock >>/home/$user_name/.profile
-echo export PATH=/home/$user_name/bin:$PATH >>/home/$user_name/.profile
+echo export DOCKER_HOST=unix:///run/user/$user_id/docker.sock >>/home/$user_name/.bashrc
+echo export PATH=/home/$user_name/bin:$PATH >>/home/$user_name/.bashrc
 
 # Run docker service by default
 loginctl enable-linger $user_name

--- a/examples/ubuntu/templates/user-data.sh
+++ b/examples/ubuntu/templates/user-data.sh
@@ -7,13 +7,14 @@ ${pre_install}
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
     awscli \
-    jq \
-    curl \
-    wget \
-    git \
-    uidmap \
     build-essential \
-    unzip
+    curl \
+    git \
+    iptables \
+    jq \
+    uidmap \
+    unzip \
+    wget
 
 user_name=ubuntu
 user_id=$(id -ru $user_name)


### PR DESCRIPTION
A fresh installation on Ubuntu 22.04 is missing iptables, which is required for rootless docker do work.

- adding iptables apt-get install list
- sorting apt-get install list

