### PR TITLE
fix: Webhook lambda misleading log

### DIFF
--- a/modules/webhook/lambdas/webhook/src/webhook/handler.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.ts
@@ -144,8 +144,8 @@ async function handleWorkflowJob(
       eventType: githubEvent,
       installationId: installationId,
     });
+    logger.info(`Successfully queued job for ${body.repository.full_name}`, LogFields.print());
   }
-  logger.info(`Successfully queued job for ${body.repository.full_name}`, LogFields.print());
   return { statusCode: 201 };
 }
 


### PR DESCRIPTION
In webhook lambda `handler.ts` there is a misleading log that suggests that the job was queued.
When the action is not in the queued state (e.g. completed or canceled), this log may be misleading.