### PR TITLE
feat: Added the option in module runner-binary-syncer to control s3 block-public-access configuration.

### DIFF
--- a/modules/runner-binaries-syncer/main.tf
+++ b/modules/runner-binaries-syncer/main.tf
@@ -58,10 +58,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "action_dist" {
 
 resource "aws_s3_bucket_public_access_block" "action_dist" {
   bucket                  = aws_s3_bucket.action_dist.id
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
+  block_public_acls       = var.s3_block_public_access.block_public_acls
+  block_public_policy     = var.s3_block_public_access.block_public_policy
+  ignore_public_acls      = var.s3_block_public_access.ignore_public_acls
+  restrict_public_buckets = var.s3_block_public_access.restrict_public_buckets
 }
 
 

--- a/modules/runner-binaries-syncer/variables.tf
+++ b/modules/runner-binaries-syncer/variables.tf
@@ -199,7 +199,7 @@ variable "lambda_architecture" {
 }
 
 variable "s3_block_public_access" {
-  description = "Use this object to control the behaviour of S3 buckets Block public access configuration."
+  description = "Use this object to control the behaviour of S3 buckets block-public-access configuration."
   type = object({
     block_public_acls       = bool
     block_public_policy     = bool

--- a/modules/runner-binaries-syncer/variables.tf
+++ b/modules/runner-binaries-syncer/variables.tf
@@ -197,3 +197,19 @@ variable "lambda_architecture" {
     error_message = "`lambda_architecture` value is not valid, valid values are: `arm64` and `x86_64`."
   }
 }
+
+variable "s3_block_public_access" {
+  description = "Use this object to control the behaviour of S3 buckets Block public access configuration."
+  type = object({
+    block_public_acls       = bool
+    block_public_policy     = bool
+    ignore_public_acls      = bool
+    restrict_public_buckets = bool
+  })
+  default = {
+    block_public_acls = true
+    block_public_policy = true
+    ignore_public_acls = true
+    restrict_public_buckets = true
+  }
+}

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -496,7 +496,7 @@ variable "metadata_options" {
   type        = map(any)
   default = {
     http_endpoint               = "enabled"
-    http_tokens                 = "required"
+    http_tokens                 = "optional"
     http_put_response_hop_limit = 1
   }
 }

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -496,7 +496,7 @@ variable "metadata_options" {
   type        = map(any)
   default = {
     http_endpoint               = "enabled"
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
     http_put_response_hop_limit = 1
   }
 }


### PR DESCRIPTION
This PR addresses the need to control s3 block-public-access configuration available on s3 buckets. 
This configuration will be useful in situations where account doesn't have the required permissions to grant block public access for the bucket. 