### PR TITLE
fix: Ignore case for runner labels.

### DIFF
--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "scale_up" {
       NODE_TLS_REJECT_UNAUTHORIZED         = var.ghes_url != null && !var.ghes_ssl_verify ? 0 : 1
       PARAMETER_GITHUB_APP_ID_NAME         = var.github_app_parameters.id.name
       PARAMETER_GITHUB_APP_KEY_BASE64_NAME = var.github_app_parameters.key_base64.name
-      RUNNER_EXTRA_LABELS                  = var.runner_extra_labels
+      RUNNER_EXTRA_LABELS                  = lower(var.runner_extra_labels)
       RUNNER_GROUP_NAME                    = var.runner_group_name
       RUNNERS_MAXIMUM_COUNT                = var.runners_maximum_count
       SUBNET_IDS                           = join(",", var.subnet_ids)

--- a/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.test.ts
@@ -129,7 +129,7 @@ describe('handler', () => {
         ...workflowjob_event,
         workflow_job: {
           ...workflowjob_event.workflow_job,
-          labels: ['self-hosted', 'test'],
+          labels: ['self-hosted', 'Test'],
         },
       });
       const resp = await handle(
@@ -141,7 +141,7 @@ describe('handler', () => {
     });
 
     it('Check runner labels accept job with mixed order.', async () => {
-      process.env.RUNNER_LABELS = '["linux", "test", "self-hosted"]';
+      process.env.RUNNER_LABELS = '["linux", "TEST", "self-hosted"]';
       process.env.ENABLE_WORKFLOW_JOB_LABELS_CHECK = 'true';
       process.env.WORKFLOW_JOB_LABELS_CHECK_ALL = 'true';
       const event = JSON.stringify({

--- a/modules/webhook/lambdas/webhook/src/webhook/handler.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.ts
@@ -84,7 +84,7 @@ function readEnvironmentVariables() {
   const workflowLabelCheckAll = JSON.parse(workflowLabelCheckAllEnv) as boolean;
   const repositoryWhiteListEnv = process.env.REPOSITORY_WHITE_LIST || '[]';
   const repositoryWhiteList = JSON.parse(repositoryWhiteListEnv) as Array<string>;
-  const runnerLabelsEnv = process.env.RUNNER_LABELS || '[]';
+  const runnerLabelsEnv = (process.env.RUNNER_LABELS || '[]').toLowerCase();;
   const runnerLabels = JSON.parse(runnerLabelsEnv) as Array<string>;
   return { environment, repositoryWhiteList, enableWorkflowLabelCheck, workflowLabelCheckAll, runnerLabels };
 }
@@ -178,8 +178,8 @@ function isRepoNotAllowed(repoFullName: string, repositoryWhiteList: string[]): 
 function canRunJob(job: WorkflowJobEvent, runnerLabels: string[], workflowLabelCheckAll: boolean): boolean {
   const workflowJobLabels = job.workflow_job.labels;
   const match = workflowLabelCheckAll
-    ? workflowJobLabels.every((l) => runnerLabels.includes(l))
-    : workflowJobLabels.some((l) => runnerLabels.includes(l));
+    ? workflowJobLabels.every((l) => runnerLabels.includes(l.toLowerCase()))
+    : workflowJobLabels.some((l) => runnerLabels.includes(l.toLowerCase()));
 
   logger.debug(
     `Received workflow job event with labels: '${JSON.stringify(workflowJobLabels)}'. The event does ${

--- a/modules/webhook/lambdas/webhook/src/webhook/handler.ts
+++ b/modules/webhook/lambdas/webhook/src/webhook/handler.ts
@@ -84,7 +84,7 @@ function readEnvironmentVariables() {
   const workflowLabelCheckAll = JSON.parse(workflowLabelCheckAllEnv) as boolean;
   const repositoryWhiteListEnv = process.env.REPOSITORY_WHITE_LIST || '[]';
   const repositoryWhiteList = JSON.parse(repositoryWhiteListEnv) as Array<string>;
-  const runnerLabelsEnv = (process.env.RUNNER_LABELS || '[]').toLowerCase();;
+  const runnerLabelsEnv = (process.env.RUNNER_LABELS || '[]').toLowerCase();
   const runnerLabels = JSON.parse(runnerLabelsEnv) as Array<string>;
   return { environment, repositoryWhiteList, enableWorkflowLabelCheck, workflowLabelCheckAll, runnerLabels };
 }

--- a/modules/webhook/webhook.tf
+++ b/modules/webhook/webhook.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "webhook" {
       LOG_LEVEL                        = var.log_level
       LOG_TYPE                         = var.log_type
       REPOSITORY_WHITE_LIST            = jsonencode(var.repository_white_list)
-      RUNNER_LABELS                    = jsonencode(split(",", var.runner_labels))
+      RUNNER_LABELS                    = jsonencode(split(",", lower(var.runner_labels)))
       SQS_URL_WEBHOOK                  = var.sqs_build_queue.id
       SQS_IS_FIFO                      = var.sqs_build_queue_fifo
     }


### PR DESCRIPTION
GitHub is not specifying if labels of runners are case senstive or not. But experiments make it clear that runners accept jobs without checking the cases of labels. This PR will ensure all labels are always set in lower case and all checks are don with lower case.

