### PR TITLE
fix(runners): Set the default Windows AMI to Server 2022

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -15,7 +15,7 @@ locals {
   kms_key_arn           = var.kms_key_arn != null ? var.kms_key_arn : ""
 
   default_ami = {
-    "windows" = { name = ["Windows_Server-2019-English-Core-ContainersLatest-*"] }
+    "windows" = { name = ["Windows_Server-2022-English-Core-ContainersLatest-*"] }
     "linux"   = var.runner_architecture == "arm64" ? { name = ["amzn2-ami-kernel-5.*-hvm-*-arm64-gp2"] } : { name = ["amzn2-ami-kernel-5.*-hvm-*-x86_64-gp2"] }
   }
 

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -15,7 +15,7 @@ locals {
   kms_key_arn           = var.kms_key_arn != null ? var.kms_key_arn : ""
 
   default_ami = {
-    "windows" = { name = ["Windows_Server-20H2-English-Core-ContainersLatest-*"] }
+    "windows" = { name = ["Windows_Server-2019-English-Core-ContainersLatest-*"] }
     "linux"   = var.runner_architecture == "arm64" ? { name = ["amzn2-ami-kernel-5.*-hvm-*-arm64-gp2"] } : { name = ["amzn2-ami-kernel-5.*-hvm-*-x86_64-gp2"] }
   }
 


### PR DESCRIPTION
AWS removed the Windows Server 20H2 AMIs on [2022-08-09](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-windows-ami-version-history.html), causing this
module to fail when trying to lookup AMIs with that name.