### PR TITLE
fix(runners): Pass allocation strategy

### DIFF
--- a/modules/runners/lambdas/runners/src/aws/runners.ts
+++ b/modules/runners/lambdas/runners/src/aws/runners.ts
@@ -148,7 +148,7 @@ export async function createRunner(runnerParameters: RunnerInputParameters): Pro
         ],
         SpotOptions: {
           MaxTotalPrice: runnerParameters.ec2instanceCriteria.maxSpotPrice,
-          AllocationStrategy: 'capacity-optimized',
+          AllocationStrategy: runnerParameters.ec2instanceCriteria.instanceAllocationStrategy,
         },
         TargetCapacitySpecification: {
           TotalTargetCapacity: numberOfRunners,


### PR DESCRIPTION
Seems that the allocation strategy isn't passed.

*Note: First time doing anything in type script*