### PR TITLE
chore: Use `https` instead of `git` in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.52.0
     hooks:
       - id: terraform_fmt
       - id: terraform_tflint
       - id: terraform_docs
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-merge-conflict


### PR DESCRIPTION
This fixes the problem that `pre-commit` cannot be newly configured because `git://` protocol has been shutdown in GitHub on March 15, 2022.

https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git