### PR TITLE
feat: Encrypted data at REST on SQS by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,9 +62,12 @@ resource "aws_sqs_queue" "queued_builds" {
     maxReceiveCount     = var.redrive_build_queue.maxReceiveCount
   }) : null
 
+  sqs_managed_sse_enabled           = var.queue_encryption.sqs_managed_sse_enabled
+  kms_master_key_id                 = var.queue_encryption.kms_master_key_id
+  kms_data_key_reuse_period_seconds = var.queue_encryption.kms_data_key_reuse_period_seconds
+
   tags = var.tags
 }
-
 
 resource "aws_sqs_queue_policy" "build_queue_dlq_policy" {
   count     = var.redrive_build_queue.enabled ? 1 : 0
@@ -75,6 +78,10 @@ resource "aws_sqs_queue_policy" "build_queue_dlq_policy" {
 resource "aws_sqs_queue" "queued_builds_dlq" {
   count = var.redrive_build_queue.enabled ? 1 : 0
   name  = "${var.prefix}-queued-builds_dead_letter"
+
+  sqs_managed_sse_enabled           = var.queue_encryption.sqs_managed_sse_enabled
+  kms_master_key_id                 = var.queue_encryption.kms_master_key_id
+  kms_data_key_reuse_period_seconds = var.queue_encryption.kms_data_key_reuse_period_seconds
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -669,3 +669,22 @@ variable "enable_runner_binaries_syncer" {
   type        = bool
   default     = true
 }
+
+variable "queue_encryption" {
+  description = "Configure how data on queues managed by the modules in ecrypted at REST. Options are encryped via SSE, non encrypted and via KMSS. By default encryptes via SSE is enabled. See for more details the Terraform `aws_sqs_queue` resource https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue."
+  type = object({
+    kms_data_key_reuse_period_seconds = number
+    kms_master_key_id                 = string
+    sqs_managed_sse_enabled           = bool
+  })
+  default = {
+    kms_data_key_reuse_period_seconds = null
+    kms_master_key_id                 = null
+    sqs_managed_sse_enabled           = true
+  }
+  validation {
+    condition     = var.queue_encryption == null || var.queue_encryption.sqs_managed_sse_enabled != null && var.queue_encryption.kms_master_key_id == null && var.queue_encryption.kms_data_key_reuse_period_seconds == null || var.queue_encryption.sqs_managed_sse_enabled == null && var.queue_encryption.kms_master_key_id != null
+    error_message = "Invalid configuration for `queue_encryption`. Valid configurations are encryption disabled, enabled via SSE. Or encryption via KMS."
+  }
+}
+


### PR DESCRIPTION
This changed the default for encryption of messages on the SQS queues managed by the module. 

- By default messages will be encrypted via SSE.
- Optional users can use a custom key (CMK) to encrypt or decide to disable encryption at all.

Close: #2389 