### PR TITLE
feat: Remove old scale down mechanism (< 0.19.0)

### DIFF
--- a/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
@@ -444,7 +444,7 @@ describe('scaleDown', () => {
 
       expect(mockOctokit.apps.getRepoInstallation).toBeCalledTimes(2);
       expect(mockOctokit.apps.getOrgInstallation).toBeCalledTimes(1);
-      expect(terminateRunner).toBeCalledTimes(8);
+      expect(terminateRunner).toBeCalledTimes(7);
       for (const toTerminate of RUNNERS_ALL_REMOVED) {
         expect(terminateRunner).toHaveBeenCalledWith(toTerminate.instanceId);
       }
@@ -558,7 +558,7 @@ describe('scaleDown', () => {
 
       expect(mockOctokit.apps.getRepoInstallation).toBeCalledTimes(2);
       expect(mockOctokit.apps.getOrgInstallation).toBeCalledTimes(1);
-      expect(terminateRunner).toBeCalledTimes(8);
+      expect(terminateRunner).toBeCalledTimes(7);
       for (const toTerminate of RUNNERS_ALL_REMOVED) {
         expect(terminateRunner).toHaveBeenCalledWith(toTerminate.instanceId);
       }

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -220,21 +220,6 @@ async function listAndSortRunners(environment: string) {
   });
 }
 
-/**
- * We are moving to a new strategy to find and remove runners, this function will ensure
- * during migration runners tagged in the old way are removed.
- */
-function filterLegacyRunners(ec2runners: RunnerList[]): RunnerInfo[] {
-  return ec2runners
-    .filter((ec2Runner) => ec2Runner.repo || ec2Runner.org)
-    .map((ec2Runner) => ({
-      instanceId: ec2Runner.instanceId,
-      launchTime: ec2Runner.launchTime,
-      type: ec2Runner.org ? 'Org' : 'Repo',
-      owner: ec2Runner.org ? (ec2Runner.org as string) : (ec2Runner.repo as string),
-    }));
-}
-
 function filterRunners(ec2runners: RunnerList[]): RunnerInfo[] {
   return ec2runners.filter((ec2Runner) => ec2Runner.type) as RunnerInfo[];
 }
@@ -256,12 +241,9 @@ export async function scaleDown(): Promise<void> {
     logger.debug(`No active runners found for environment: '${environment}'`, LogFields.print());
     return;
   }
-  const legacyRunners = filterLegacyRunners(ec2Runners);
-  logger.debug(JSON.stringify(legacyRunners), LogFields.print());
-  const runners = filterRunners(ec2Runners);
 
+  const runners = filterRunners(ec2Runners);
   await evaluateAndRemoveRunners(runners, scaleDownConfigs);
-  await evaluateAndRemoveRunners(legacyRunners, scaleDownConfigs);
 
   const activeEc2RunnersCountAfter = (await listAndSortRunners(environment)).length;
   logger.info(


### PR DESCRIPTION
Removing old scale down mechanism which was used till release 0.19.0. To support migration, we kept the old mechanism. New scale down based on owner logic was introduced via PR #1065

Test via deployment

- [x] org level
- [x] repo level