### PR TITLE
Add support for looking up pre-built runner AMI ID from an SSM parameter at instance launch time

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -157,6 +157,7 @@ module "runners" {
   runner_architecture = var.runner_architecture
   ami_filter          = var.ami_filter
   ami_owners          = var.ami_owners
+  ami_id_ssm_param    = var.ami_id_ssm_param
 
   sqs_build_queue                      = aws_sqs_queue.queued_builds
   github_app_parameters                = local.github_app_parameters

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-up.ts
@@ -32,6 +32,7 @@ interface CreateEC2RunnerConfig {
   launchTemplateName: string;
   ec2instanceCriteria: RunnerInputParameters['ec2instanceCriteria'];
   numberOfRunners?: number;
+  amiIdSsmParam?: string;
 }
 
 function generateRunnerServiceConfig(githubRunnerConfig: CreateGitHubRunnerConfig, token: string) {
@@ -159,6 +160,7 @@ export async function scaleUp(eventSource: string, payload: ActionRequestMessage
   const instanceMaxSpotPrice = process.env.INSTANCE_MAX_SPOT_PRICE;
   const instanceAllocationStrategy = process.env.INSTANCE_ALLOCATION_STRATEGY || 'lowest-price'; // same as AWS default
   const enableJobQueuedCheck = yn(process.env.ENABLE_JOB_QUEUED_CHECK, { default: true });
+  const amiIdSsmParam = process.env.AMI_ID_SSM_PARAM;
 
   if (ephemeralEnabled && payload.eventType !== 'workflow_job') {
     logger.warn(
@@ -222,6 +224,7 @@ export async function scaleUp(eventSource: string, payload: ActionRequestMessage
           environment,
           launchTemplateName,
           subnets,
+          amiIdSsmParam,
         },
         githubInstallationClient,
       );

--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -36,6 +36,7 @@ resource "aws_lambda_function" "scale_up" {
       RUNNER_GROUP_NAME                    = var.runner_group_name
       RUNNERS_MAXIMUM_COUNT                = var.runners_maximum_count
       SUBNET_IDS                           = join(",", var.subnet_ids)
+      AMI_ID_SSM_PARAM                     = var.ami_id_ssm_param
     }
   }
 
@@ -109,4 +110,26 @@ resource "aws_iam_role_policy_attachment" "scale_up_vpc_execution_role" {
   count      = length(var.lambda_subnet_ids) > 0 ? 1 : 0
   role       = aws_iam_role.scale_up.name
   policy_arn = "arn:${var.aws_partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+resource "aws_iam_role_policy" "ami_id_ssm_param_read" {
+  count = var.ami_id_ssm_param != null ? 1 : 0
+  name  = "${var.prefix}-ami-id-ssm-param-read"
+  role  = aws_iam_role.scale_up.name
+  policy = <<-JSON
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "ssm:GetParameter"
+          ],
+          "Resource": [
+            "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${trimprefix(var.ami_id_ssm_param, "/")}"
+          ]
+        }
+      ]
+    }
+  JSON
 }

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -155,6 +155,12 @@ variable "ami_owners" {
   default     = ["amazon"]
 }
 
+variable "ami_id_ssm_param" {
+  description = "SSM parameter (data type aws:ec2:image) that contains the AMI ID to launch instances from. Overrides ami_filter"
+  type        = string
+  default     = null
+}
+
 variable "enabled_userdata" {
   description = "Should the userdata script be enabled for the runner. Set this to false if you are using your own prebuilt AMI"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -302,11 +302,19 @@ variable "ami_filter" {
   type        = map(list(string))
   default     = null
 }
+
 variable "ami_owners" {
   description = "The list of owners used to select the AMI of action runner instances."
   type        = list(string)
   default     = ["amazon"]
 }
+
+variable "ami_id_ssm_param" {
+  description = "SSM parameter (data type aws:ec2:image) that contains the AMI ID to launch instances from. Overrides ami_filter"
+  type        = string
+  default     = null
+}
+
 variable "lambda_s3_bucket" {
   description = "S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly."
   default     = null


### PR DESCRIPTION
👋 

Use case: we build custom runner AMIs periodically (as new actions/runner versions are released), and we have disabled auto-updates on the runners (to keep things more predictable and fast). Now the problem is that currently we need to re-apply the runner terraform config, to pick up a newly-built AMI (since it is looked up by the terraform data source).

This PR introduces an option to have the scale up lambda look up the runner AMI ID from an SSM parameter at _runner instance launch time_, thereby allowing us to update the AMI, without having to re-apply runner stacks.

To make this work fully automated, we'd also amend our AMI build workflow to update this AMI ID SSM parameter, as a new AMI version is built. Then it would be automatically picked up by the runner stack.

This PR is a draft for now, because I assume we'd need to add some tests and amend documentation.

I have quickly smoke-tested the code in an actual GitHub repo/AWS account.

Let me know what you think.

Thanks,
Jukka