### PR TITLE
fix: replacing deprecated set-output in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         id: lambda
         env:
           LAMBDA: ${{ matrix.lambda }}
-        run: echo ::set-output name=name::${LAMBDA##*/}
+        run: echo "name=${LAMBDA##*/}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
       - name: Add zip
         run: apt update && apt install zip


### PR DESCRIPTION
Replacing deprecated `set-output` to use env `$GITHUB_OUTPUT` instead.

Blogg post about deprecation:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/