### PR TITLE
fix: Use aws_partition for govcloud users in ami_id_ssm_parameter_read policy definition

### DIFF
--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -126,7 +126,7 @@ resource "aws_iam_role_policy" "ami_id_ssm_parameter_read" {
             "ssm:GetParameter"
           ],
           "Resource": [
-            "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${trimprefix(var.ami_id_ssm_parameter_name, "/")}"
+            "arn:${var.aws_partition}:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/${trimprefix(var.ami_id_ssm_parameter_name, "/")}"
           ]
         }
       ]


### PR DESCRIPTION
The role policy needs to use the variable so that when deployed into govcloud (or other non-default partition setup) the referenced parameter can be created and/or found.