### PR TITLE
docs: Remove the beta warning from ephmeral runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ For time zones please check [TZ database name column](https://en.wikipedia.org/w
 
 ### Ephemeral runners
 
-Currently a beta feature! You can configure runners to be ephemeral, runners will be used only for one job. The feature should be used in conjunction with listening for the workflow job event. Please consider the following:
+You can configure runners to be ephemeral, runners will be used only for one job. The feature should be used in conjunction with listening for the workflow job event. Please consider the following:
 
 - The scale down lambda is still active, and should only remove orphan instances. But there is no strict check in place. So ensure you configure the `minimum_running_time_in_minutes` to a value that is high enough to got your runner booted and connected to avoid it got terminated before executing a job.
 - The messages sent from the webhook lambda to scale-up lambda are by default delayed delayed by SQS, to give available runners to option to start the job before the decision is made to scale more runners. For ephemeral runners there is no need to wait. Set `delay_webhook_event` to `0`.


### PR DESCRIPTION
Remove the beta warning for ephemeral runners. Thanks @mattsb42 for pointing out.