### PR TITLE
chore: bump min terraform version to 1.3.0

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform: [1.0.11, 1.1.9, 1.2.9, "latest"]
+        terraform: [1.3.0, "latest"]
         example:
           ["default", "ubuntu", "prebuilt", "arm64", "ephemeral", "windows"]
     defaults:

--- a/examples/arm64/versions.tf
+++ b/examples/arm64/versions.tf
@@ -11,5 +11,5 @@ terraform {
       source = "hashicorp/random"
     }
   }
-  required_version = ">= 0.14"
+  required_version = ">= 1.3.0"
 }

--- a/examples/default/versions.tf
+++ b/examples/default/versions.tf
@@ -11,5 +11,5 @@ terraform {
       source = "hashicorp/random"
     }
   }
-  required_version = ">= 1"
+  required_version = ">= 1.3.0"
 }

--- a/examples/ephemeral/versions.tf
+++ b/examples/ephemeral/versions.tf
@@ -11,5 +11,5 @@ terraform {
       source = "hashicorp/random"
     }
   }
-  required_version = ">= 1"
+  required_version = ">= 1.3.0"
 }

--- a/examples/multi-runner/versions.tf
+++ b/examples/multi-runner/versions.tf
@@ -11,5 +11,5 @@ terraform {
       source = "hashicorp/random"
     }
   }
-  required_version = ">= 1.3"
+  required_version = ">= 1.3.0"
 }

--- a/examples/permissions-boundary/setup/versions.tf
+++ b/examples/permissions-boundary/setup/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 4.0"
     }
   }
-  required_version = ">= 1"
+  required_version = ">= 1.3.0"
 }

--- a/examples/permissions-boundary/versions.tf
+++ b/examples/permissions-boundary/versions.tf
@@ -11,5 +11,5 @@ terraform {
       source = "hashicorp/random"
     }
   }
-  required_version = ">= 1"
+  required_version = ">= 1.3.0"
 }

--- a/examples/prebuilt/versions.tf
+++ b/examples/prebuilt/versions.tf
@@ -11,5 +11,5 @@ terraform {
       source = "hashicorp/random"
     }
   }
-  required_version = ">= 1"
+  required_version = ">= 1.3.0"
 }

--- a/examples/ubuntu/versions.tf
+++ b/examples/ubuntu/versions.tf
@@ -11,5 +11,5 @@ terraform {
       source = "hashicorp/random"
     }
   }
-  required_version = ">= 1"
+  required_version = ">= 1.3.0"
 }

--- a/examples/windows/versions.tf
+++ b/examples/windows/versions.tf
@@ -11,5 +11,5 @@ terraform {
       source = "hashicorp/random"
     }
   }
-  required_version = ">= 1"
+  required_version = ">= 1.3.0"
 }

--- a/modules/download-lambda/versions.tf
+++ b/modules/download-lambda/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.1"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {

--- a/modules/runner-binaries-syncer/versions.tf
+++ b/modules/runner-binaries-syncer/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.1"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {

--- a/modules/runners/versions.tf
+++ b/modules/runners/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.1"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {

--- a/modules/setup-iam-permissions/versions.tf
+++ b/modules/setup-iam-permissions/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.1"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {

--- a/modules/ssm/versions.tf
+++ b/modules/ssm/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.1"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {

--- a/modules/webhook/versions.tf
+++ b/modules/webhook/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.1"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14.1"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description

To make it possible to refactor, and use optional defaults introduced in Terraform 1.3.x the minimal version will set to 1.3.0. This will avoid that we need later another breaking release to support the new Terraform constructs.

## Migration

Only required migration is to upgrade Terraform to 1.3.x. For any 1.x version this should have minor impact.

