### PR TITLE
fix: Updated the fifo flag for deadletter queue.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ resource "aws_sqs_queue_policy" "build_queue_dlq_policy" {
 
 resource "aws_sqs_queue" "queued_builds_dlq" {
   count = var.redrive_build_queue.enabled ? 1 : 0
-  name  = "${var.prefix}-queued-builds_dead_letter${each.value.fifo ? ".fifo" : ""}"
+  name  = "${var.prefix}-queued-builds_dead_letter${var.fifo_build_queue ? ".fifo" : ""}"
 
   sqs_managed_sse_enabled           = var.queue_encryption.sqs_managed_sse_enabled
   kms_master_key_id                 = var.queue_encryption.kms_master_key_id

--- a/main.tf
+++ b/main.tf
@@ -106,8 +106,8 @@ resource "aws_sqs_queue" "queued_builds_dlq" {
   sqs_managed_sse_enabled           = var.queue_encryption.sqs_managed_sse_enabled
   kms_master_key_id                 = var.queue_encryption.kms_master_key_id
   kms_data_key_reuse_period_seconds = var.queue_encryption.kms_data_key_reuse_period_seconds
-  fifo_queue = var.fifo_build_queue
-  tags = var.tags
+  fifo_queue                        = var.fifo_build_queue
+  tags                              = var.tags
 }
 
 module "ssm" {

--- a/main.tf
+++ b/main.tf
@@ -101,12 +101,12 @@ resource "aws_sqs_queue_policy" "build_queue_dlq_policy" {
 
 resource "aws_sqs_queue" "queued_builds_dlq" {
   count = var.redrive_build_queue.enabled ? 1 : 0
-  name  = "${var.prefix}-queued-builds_dead_letter"
+  name  = "${var.prefix}-queued-builds_dead_letter${each.value.fifo ? ".fifo" : ""}"
 
   sqs_managed_sse_enabled           = var.queue_encryption.sqs_managed_sse_enabled
   kms_master_key_id                 = var.queue_encryption.kms_master_key_id
   kms_data_key_reuse_period_seconds = var.queue_encryption.kms_data_key_reuse_period_seconds
-
+  fifo_queue = var.fifo_build_queue
   tags = var.tags
 }
 


### PR DESCRIPTION
This PR addresses the issue #2591 where if the sqs queues are fifo, the corresponding Dead Letter queues should be fifo too.