### PR TITLE
fix(multi-runner): Default value validation error

### DIFF
--- a/modules/multi-runner/runners.tf
+++ b/modules/multi-runner/runners.tf
@@ -10,7 +10,7 @@ module "runners" {
     "ghr:environment" = "${var.prefix}-${each.key}"
   })
 
-  s3_runner_binaries = each.value.runner_config.enable_runner_binaries_syncer ? local.runner_binaries_by_os_and_arch_map["${each.value.runner_config.runner_os}_${each.value.runner_config.runner_architecture}"] : {}
+  s3_runner_binaries = each.value.runner_config.enable_runner_binaries_syncer ? local.runner_binaries_by_os_and_arch_map["${each.value.runner_config.runner_os}_${each.value.runner_config.runner_architecture}"] : null
 
   ssm_paths = {
     root   = "${local.ssm_root_path}/${var.prefix}-${each.key}"


### PR DESCRIPTION
Avoid validation error when `enable_runner_binaries_syncer=false`.

```
Error: Invalid value for input variable
│
│   on .terraform/modules/multi-runner/modules/multi-runner/runners.tf line 13, in module "runners":
│   13:   s3_runner_binaries = each.value.runner_config.enable_runner_binaries_syncer ? local.runner_binaries_by_os_and_arch_map["${each.value.runner_config.runner_os}_${each.value.runner_config.runner_architecture}"] : {}
│
│ The given value is not suitable for module.multi-runner.module.runners["linux-x64-default"].var.s3_runner_binaries declared at
│ .terraform/modules/multi-runner/modules/runners/variables.tf:49,1-30: attributes "arn", "id", and "key" are required.
```