### PR TITLE
fix: Adding missing input lambda vpc vars to syncer module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -289,5 +289,8 @@ module "runner_binaries" {
   log_type  = var.log_type
   log_level = var.log_level
 
+  lambda_subnet_ids         = var.lambda_subnet_ids
+  lambda_security_group_ids = var.lambda_security_group_ids
+
   lambda_principals = var.lambda_principals
 }


### PR DESCRIPTION
The variables [lambda_subnet_ids](https://github.com/philips-labs/terraform-aws-github-runner/blob/develop/modules/runner-binaries-syncer/variables.tf#L156) and [lambda_security_group_ids](https://github.com/philips-labs/terraform-aws-github-runner/blob/develop/modules/runner-binaries-syncer/variables.tf#L162) are declared in the syncer module but are not passed from the root [main.tf](https://github.com/philips-labs/terraform-aws-github-runner/blob/develop/main.tf#L257), so the syncer lambda is created without the security group ids and subnets.
