### PR TITLE
fix: Remove extraneous slashes from SSM paths, other typos

### DIFF
--- a/modules/runners/templates/start-runner.ps1
+++ b/modules/runners/templates/start-runner.ps1
@@ -23,7 +23,7 @@ Write-Host  "Reteieved ghr:environment tag - ($environment)"
 $ssm_config_path=$tags.Tags.where( {$_.Key -eq 'ghr:ssm_config_path'}).value
 Write-Host  "Reteieved ghr:ssm_config_path tag - ($ssm_config_path)"
 
-$parameters=$(aws ssm get-parameters-by-path --path "/$ssm_config_path" --region "$Region" --query "Parameters[*].{Name:Name,Value:Value}") | ConvertFrom-Json
+$parameters=$(aws ssm get-parameters-by-path --path "$ssm_config_path" --region "$Region" --query "Parameters[*].{Name:Name,Value:Value}") | ConvertFrom-Json
 Write-Host  "Retrieved parameters from AWS SSM"
 
 $run_as=$parameters.where( {$_.Name -eq "/$ssm_config_path/run_as"}).value

--- a/modules/runners/templates/start-runner.ps1
+++ b/modules/runners/templates/start-runner.ps1
@@ -21,22 +21,22 @@ $environment=$tags.Tags.where( {$_.Key -eq 'ghr:environment'}).value
 Write-Host  "Reteieved ghr:environment tag - ($environment)"
 
 $ssm_config_path=$tags.Tags.where( {$_.Key -eq 'ghr:ssm_config_path'}).value
-Write-Host  "Reteieved ghr:ssm_config_path tag - ($ssm_config_path)"
+Write-Host  "Retrieved ghr:ssm_config_path tag - ($ssm_config_path)"
 
 $parameters=$(aws ssm get-parameters-by-path --path "$ssm_config_path" --region "$Region" --query "Parameters[*].{Name:Name,Value:Value}") | ConvertFrom-Json
 Write-Host  "Retrieved parameters from AWS SSM"
 
-$run_as=$parameters.where( {$_.Name -eq "/$ssm_config_path/run_as"}).value
-Write-Host  "Retrieved /$ssm_config_path/run_as parameter - ($run_as)"
+$run_as=$parameters.where( {$_.Name -eq "$ssm_config_path/run_as"}).value
+Write-Host  "Retrieved $ssm_config_path/run_as parameter - ($run_as)"
 
-$enable_cloudwatch_agent=$parameters.where( {$_.Name -eq "/$ssm_config_pathr/enable_cloudwatch"}).value
-Write-Host  "Retrieved /$ssm_config_path/enable_cloudwatch parameter - ($enable_cloudwatch_agent)"
+$enable_cloudwatch_agent=$parameters.where( {$_.Name -eq "$ssm_config_path/enable_cloudwatch"}).value
+Write-Host  "Retrieved $ssm_config_path/enable_cloudwatch parameter - ($enable_cloudwatch_agent)"
 
-$agent_mode=$parameters.where( {$_.Name -eq "/$ssm_config_path/agent_mode"}).value
-Write-Host  "Retrieved /$ssm_config_path/agent_mode parameter - ($agent_mode)"
+$agent_mode=$parameters.where( {$_.Name -eq "$ssm_config_path/agent_mode"}).value
+Write-Host  "Retrieved $ssm_config_path/agent_mode parameter - ($agent_mode)"
 
-$token_path=$parameters.where( {$_.Name -eq "/$ssm_config_path/token_path"}).value
-Write-Host  "Retrieved /$ssm_config_path/token_path parameter - ($token_path)"
+$token_path=$parameters.where( {$_.Name -eq "$ssm_config_path/token_path"}).value
+Write-Host  "Retrieved $ssm_config_path/token_path parameter - ($token_path)"
 
 
 if ($enable_cloudwatch_agent -eq "true")


### PR DESCRIPTION
I'm trying out v2.0.0-next.5 after using v1.18.0 successfully, and had a problem where my Windows runners failed to start up.

Connecting to the machine with SSM and looking at `c:\UserData.log`, the problem was that an extra slash was being added at the start of SSM paths. So instead of retrieving `/github-actions-runner/whatever`, it would try to retrieve `//github-actions-runner/whatever` and fail. So this PR removes the seemingly extraneous slashes, and now my runners are working well.

It's also possible that I've misconfigured something such that `$ssm_config_path` is not supposed to start with a slash, but it does in my case. Please let me know if this might be the case.

This PR also fixes a couple of typos in the powershell start-runner script.