### PR TITLE
refactor: Migrate to release via a PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-      - develop
-  workflow_dispatch:
+      - refactor/release
 
 jobs:
   prepare:
@@ -15,6 +14,9 @@ jobs:
     strategy:
       matrix:
         lambda: ["modules/webhook/lambdas/webhook", "modules/runner-binaries-syncer/lambdas/runner-binaries-syncer", "modules/runners/lambdas/runners"]
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Extract lambda name
         id: lambda
@@ -38,65 +40,59 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       prepare
+    outputs:
+      upload_url: ${{ steps.release.outputs.upload_url }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      actions: write
     steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/download-artifact@v3
-        with:
-          name: webhook
-          path: artifacts
-      - uses: actions/download-artifact@v3
-        with:
-          name: runners
-          path: artifacts
-      - uses: actions/download-artifact@v3
-        with:
-          name: runner-binaries-syncer
-          path: artifacts
-
       - name: Get installation token
         uses: npalm/action-app-token@v1.1.0
-        id: app-token
+        id: token
         with:
           appId: ${{ secrets.FOREST_RELEASER_APP_ID }}
           appPrivateKeyBase64: ${{ secrets.FOREST_RELEASER_APP_PRIVATE_KEY_BASE64 }}
           appInstallationType: repo
           appInstallationValue: ${{ github.repository }}
 
-      - name: Dry run release
-        if: github.event_name != 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Read only token
-        run: |
-          cp .release/* .
-          yarn
-          yarn release -d --repositoryUrl https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
-
+      # bootstrap-sha and release-as needs to be removed after first release
       - name: Release
-        if: github.event_name != 'pull_request' && contains('refs/heads/main', github.ref)
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          cp .release/* .
-          yarn
-          yarn release --repositoryUrl https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
-          
-  provenance:
-    name: Generate provenance
-    runs-on: ubuntu-20.04
-    needs: 
-      release
-    if: startsWith(github.ref, 'refs/tags/')
+        id: release
+        uses: google-github-actions/release-please-action@5c07f8be172b1f6e90f9c35baf8184461b91b85f # ratchet:google-github-actions/release-please-action@v3
+        with:
+          default-branch: main
+          release-type: terraform-module
+          token: ${{ steps.token.outputs.token }}
+          last-release-sha: b404332ff8b401a5a8958317a69b9f849b794a16
+
+  assets:
+    name: upload assets
+    if: ${{ needs.release.outputs.releases_created }}
+    needs: release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        asset: ["webhook", "runner-binaries-syncer", "runners"]
+    permissions:
+      contents: write
+      actions: read
 
     steps:
-      - name: Generate provenance for release
-        uses: philips-labs/slsa-provenance-action@v0.8.0
+      - uses: actions/download-artifact@v3
         with:
-          artifact_path: release-assets
-          output_path: 'build.provenance'
-          tag_name: "${{ github.ref_name }}"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          name: ${{ matrix.asset }}
+          path: artifacts
 
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: artifacts/${{ matrix.asset }}.zip
+          asset_name: ${{ matrix.asset }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
We migrating away from release via npm sementic-release to release-please Advantage is that release will be prepared via a branch and no commits to a protected branch are needed anymore.