### PR TITLE
chore: Prefix production updates with fix to trigger releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     schedule:
       interval: "weekly"
 
+
+  # NPM production dependencies are part of the generated Lambda JavaScript.
+  # Therefore updates on production are prefixed with fix(component) to trigger releases.
+  # Development updates are prefixed with chore, and not triggering a release.
   - package-ecosystem: "npm"
     directory: "/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,9 @@ updates:
       interval: "weekly"
 
 
-  # NPM production dependencies are part of the generated Lambda JavaScript.
-  # Therefore updates on production are prefixed with fix(component) to trigger releases.
-  # Development updates are prefixed with chore, and not triggering a release.
+# NPM production dependencies are part of the generated Lambda JavaScript.
+# Therefore updates on production are prefixed with fix(component) to trigger releases.
+# Development updates are prefixed with chore, and not triggering a release.
   - package-ecosystem: "npm"
     directory: "/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
     directory: "/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer"
     schedule:
       interval: "weekly"
+    commit-message:
       prefix: "fix(syncer)"
       prefix-development: "chore(syncer)"
 
@@ -27,6 +28,7 @@ updates:
     directory: "/modules/webhook/lambdas/webhook"
     schedule:
       interval: "weekly"
+    commit-message:
       prefix: "fix(webhook)"
       prefix-development: "chore(webhook)"
 
@@ -34,5 +36,6 @@ updates:
     directory: "/modules/runners/lambdas/runners"
     schedule:
       interval: "weekly"
+    commit-message:
       prefix: "fix(runners)"
       prefix-development: "chore(runners)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,19 @@ updates:
     directory: "/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer"
     schedule:
       interval: "weekly"
+      prefix: "fix(syncer)"
+      prefix-development: "chore(syncer)"
 
   - package-ecosystem: "npm"
     directory: "/modules/webhook/lambdas/webhook"
     schedule:
       interval: "weekly"
+      prefix: "fix(webhook)"
+      prefix-development: "chore(webhook)"
 
   - package-ecosystem: "npm"
     directory: "/modules/runners/lambdas/runners"
     schedule:
       interval: "weekly"
+      prefix: "fix(runners)"
+      prefix-development: "chore(runners)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,10 @@
 # Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+# NPM production dependencies are part of the generated Lambda JavaScript.
+# Therefore updates on production are prefixed with fix(component) to trigger releases.
+# Development updates are prefixed with chore, and not triggering a release.
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -12,10 +16,6 @@ updates:
     schedule:
       interval: "weekly"
 
-
-# NPM production dependencies are part of the generated Lambda JavaScript.
-# Therefore updates on production are prefixed with fix(component) to trigger releases.
-# Development updates are prefixed with chore, and not triggering a release.
   - package-ecosystem: "npm"
     directory: "/modules/runner-binaries-syncer/lambdas/runner-binaries-syncer"
     schedule:


### PR DESCRIPTION
Set different commit prefix for development and production updates
- fix(component) for production
- chore(component) for dev dependencies