### PR TITLE
refactor(runners): Move bootTimeExceeded to runners module

### DIFF
--- a/modules/runners/lambdas/runners/src/aws/runners.ts
+++ b/modules/runners/lambdas/runners/src/aws/runners.ts
@@ -1,4 +1,5 @@
 import { EC2, SSM } from 'aws-sdk';
+import moment from 'moment';
 
 import { LogFields, logger as rootLogger } from '../logger';
 import ScaleError from './../scale-runners/ScaleError';
@@ -274,4 +275,11 @@ export async function createRunner(runnerParameters: RunnerInputParameters): Pro
       await delay(25);
     }
   }
+}
+
+// If launchTime is undefined, this will return false
+export function bootTimeExceeded(ec2Runner: { launchTime?: Date }): boolean {
+  const runnerBootTimeInMinutes = process.env.RUNNER_BOOT_TIME_IN_MINUTES;
+  const launchTimePlusBootTime = moment(ec2Runner.launchTime).utc().add(runnerBootTimeInMinutes, 'minutes');
+  return launchTimePlusBootTime < moment(new Date()).utc();
 }

--- a/modules/runners/lambdas/runners/src/pool/pool.test.ts
+++ b/modules/runners/lambdas/runners/src/pool/pool.test.ts
@@ -23,7 +23,10 @@ jest.mock('@octokit/rest', () => ({
   Octokit: jest.fn().mockImplementation(() => mockOctokit),
 }));
 
-jest.mock('./../aws/runners');
+jest.mock('./../aws/runners', () => ({
+  ...jest.requireActual('./../aws/runners'),
+  listEC2Runners: jest.fn(),
+}));
 jest.mock('./../gh-auth/gh-auth');
 jest.mock('./../scale-runners/scale-up');
 

--- a/modules/runners/lambdas/runners/src/pool/pool.ts
+++ b/modules/runners/lambdas/runners/src/pool/pool.ts
@@ -1,7 +1,6 @@
-import moment from 'moment';
 import yn from 'yn';
 
-import { RunnerList, listEC2Runners } from '../aws/runners';
+import { bootTimeExceeded, listEC2Runners } from '../aws/runners';
 import { createGithubAppAuth, createGithubInstallationAuth, createOctoClient } from '../gh-auth/gh-auth';
 import { logger as rootLogger } from '../logger';
 import { createRunners } from '../scale-runners/scale-up';
@@ -127,10 +126,4 @@ async function getInstallationId(ghesApiUrl: string, org: string): Promise<numbe
       org,
     })
   ).data.id;
-}
-
-function bootTimeExceeded(ec2Runner: RunnerList): boolean {
-  const runnerBootTimeInMinutes = process.env.RUNNER_BOOT_TIME_IN_MINUTES;
-  const launchTimePlusBootTime = moment(ec2Runner.launchTime).utc().add(runnerBootTimeInMinutes, 'minutes');
-  return launchTimePlusBootTime < moment(new Date()).utc();
 }

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-down.test.ts
@@ -27,7 +27,11 @@ jest.mock('@octokit/rest', () => ({
   Octokit: jest.fn().mockImplementation(() => mockOctokit),
 }));
 
-jest.mock('./../aws/runners');
+jest.mock('./../aws/runners', () => ({
+  ...jest.requireActual('./../aws/runners'),
+  terminateRunner: jest.fn(),
+  listEC2Runners: jest.fn(),
+}));
 jest.mock('./../gh-auth/gh-auth');
 jest.mock('./cache');
 

--- a/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
+++ b/modules/runners/lambdas/runners/src/scale-runners/scale-down.ts
@@ -3,7 +3,7 @@ import moment from 'moment';
 
 import { createGithubAppAuth, createGithubInstallationAuth, createOctoClient } from '../gh-auth/gh-auth';
 import { LogFields, logger as rootLogger } from '../logger';
-import { RunnerInfo, RunnerList, listEC2Runners, terminateRunner } from './../aws/runners';
+import { RunnerInfo, RunnerList, bootTimeExceeded, listEC2Runners, terminateRunner } from './../aws/runners';
 import { GhRunners, githubCache } from './cache';
 import { ScalingDownConfig, getIdleRunnerCount } from './scale-down-config';
 
@@ -99,12 +99,6 @@ function runnerMinimumTimeExceeded(runner: RunnerInfo): boolean {
   const launchTimePlusMinimum = moment(runner.launchTime).utc().add(minimumRunningTimeInMinutes, 'minutes');
   const now = moment(new Date()).utc();
   return launchTimePlusMinimum < now;
-}
-
-function bootTimeExceeded(ec2Runner: RunnerInfo): boolean {
-  const runnerBootTimeInMinutes = process.env.RUNNER_BOOT_TIME_IN_MINUTES;
-  const launchTimePlusBootTime = moment(ec2Runner.launchTime).utc().add(runnerBootTimeInMinutes, 'minutes');
-  return launchTimePlusBootTime < moment(new Date()).utc();
 }
 
 async function removeRunner(ec2runner: RunnerInfo, ghRunnerIds: number[]): Promise<void> {


### PR DESCRIPTION
(If preferred, this can be re-targeted to main once #2801 is merged)
It appears that Jest was replacing the `bootTimeExceeded`, possibly with a `jest.Fn()`, due to the `jest.mock('./../aws/runners')`, causing it to return undefined when called under test. The introduced changes should keep the underlying module function implementations, while mocking the functions that are needed.

Ref: https://stackoverflow.com/a/53402206

Closes #2878