### PR TITLE
fix(multi-runner): Create DLQ only if requested

### DIFF
--- a/modules/multi-runner/queues.tf
+++ b/modules/multi-runner/queues.tf
@@ -55,7 +55,7 @@ resource "aws_sqs_queue_policy" "build_queue_policy" {
 }
 
 resource "aws_sqs_queue" "queued_builds_dlq" {
-  for_each = var.multi_runner_config
+  for_each = { for config, values in var.multi_runner_config : config => values if values.redrive_build_queue.enabled }
   name     = "${var.prefix}-${each.key}-queued-builds_dead_letter${each.value.fifo ? ".fifo" : ""}"
 
   sqs_managed_sse_enabled           = var.queue_encryption.sqs_managed_sse_enabled
@@ -66,7 +66,7 @@ resource "aws_sqs_queue" "queued_builds_dlq" {
 }
 
 resource "aws_sqs_queue_policy" "build_queue_dlq_policy" {
-  for_each  = var.multi_runner_config
+  for_each  = { for config, values in var.multi_runner_config : config => values if values.redrive_build_queue.enabled }
   queue_url = aws_sqs_queue.queued_builds_dlq[each.key].id
   policy    = data.aws_iam_policy_document.deny_unsecure_transport.json
 }


### PR DESCRIPTION
Fix the problem that the setting `redrive_build_queue.enabled` was ignored.

Tested with the multirunner-example and terraform plan output.