### PR TITLE
feat(2913): Add support for webhook lambda memory size

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,8 +415,8 @@ We welcome any improvement to the standard module to make the default as secure 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.41 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.51.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 
@@ -542,6 +542,7 @@ We welcome any improvement to the standard module to make the default as secure 
 | <a name="input_userdata_template"></a> [userdata\_template](#input\_userdata\_template) | Alternative user-data template, replacing the default template. By providing your own user\_data you have to take care of installing all required software, including the action runner. Variables userdata\_pre/post\_install are ignored. | `string` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC for security groups of the action runners. | `string` | n/a | yes |
 | <a name="input_webhook_lambda_apigateway_access_log_settings"></a> [webhook\_lambda\_apigateway\_access\_log\_settings](#input\_webhook\_lambda\_apigateway\_access\_log\_settings) | n/a | <pre>object({<br>    destination_arn = string<br>    format          = string<br>  })</pre> | `null` | no |
+| <a name="input_webhook_lambda_memory_size"></a> [webhook\_lambda\_memory\_size](#input\_webhook\_lambda\_memory\_size) | Allocated memory size of the webhook lambda in MB. 128 MB to 10,240 MB, in 1-MB increments. | `number` | `128` | no |
 | <a name="input_webhook_lambda_s3_key"></a> [webhook\_lambda\_s3\_key](#input\_webhook\_lambda\_s3\_key) | S3 key for webhook lambda function. Required if using S3 bucket to specify lambdas. | `string` | `null` | no |
 | <a name="input_webhook_lambda_s3_object_version"></a> [webhook\_lambda\_s3\_object\_version](#input\_webhook\_lambda\_s3\_object\_version) | S3 object version for webhook lambda function. Useful if S3 versioning is enabled on source bucket. | `string` | `null` | no |
 | <a name="input_webhook_lambda_timeout"></a> [webhook\_lambda\_timeout](#input\_webhook\_lambda\_timeout) | Time out of the webhook lambda in seconds. | `number` | `10` | no |

--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,7 @@ module "webhook" {
   webhook_lambda_s3_object_version              = var.webhook_lambda_s3_object_version
   webhook_lambda_apigateway_access_log_settings = var.webhook_lambda_apigateway_access_log_settings
   lambda_runtime                                = var.lambda_runtime
+  lambda_memory_size                            = var.webhook_lambda_memory_size
   lambda_architecture                           = var.lambda_architecture
   lambda_zip                                    = var.webhook_lambda_zip
   lambda_timeout                                = var.webhook_lambda_timeout

--- a/modules/webhook/README.md
+++ b/modules/webhook/README.md
@@ -79,6 +79,7 @@ No modules.
 | <a name="input_github_app_parameters"></a> [github\_app\_parameters](#input\_github\_app\_parameters) | Parameter Store for GitHub App Parameters. | <pre>object({<br>    webhook_secret = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | Optional CMK Key ARN to be used for Parameter Store. | `string` | `null` | no |
 | <a name="input_lambda_architecture"></a> [lambda\_architecture](#input\_lambda\_architecture) | AWS Lambda architecture. Lambda functions using Graviton processors ('arm64') tend to have better price/performance than 'x86\_64' functions. | `string` | `"arm64"` | no |
+| <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Allocated memory size for the lambda in MB. 128 MB to 10,240 MB, in 1-MB increments. | `number` | `128` | no |
 | <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | AWS Lambda runtime. | `string` | `"nodejs18.x"` | no |
 | <a name="input_lambda_s3_bucket"></a> [lambda\_s3\_bucket](#input\_lambda\_s3\_bucket) | S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly. | `string` | `null` | no |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Time out of the lambda in seconds. | `number` | `10` | no |

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -53,6 +53,12 @@ variable "lambda_timeout" {
   default     = 10
 }
 
+variable "lambda_memory_size" {
+  description = "Allocated memory size for the lambda in MB. 128 MB to 10,240 MB, in 1-MB increments."
+  type        = number
+  default     = 128
+}
+
 variable "role_permissions_boundary" {
   description = "Permissions boundary that will be added to the created role for the lambda."
   type        = string

--- a/modules/webhook/webhook.tf
+++ b/modules/webhook/webhook.tf
@@ -6,6 +6,7 @@ resource "aws_lambda_function" "webhook" {
   source_code_hash  = var.lambda_s3_bucket == null ? filebase64sha256(local.lambda_zip) : null
   function_name     = "${var.prefix}-webhook"
   role              = aws_iam_role.webhook_lambda.arn
+  memory            = var.lambda_memory_size
   handler           = "index.githubWebhook"
   runtime           = var.lambda_runtime
   timeout           = var.lambda_timeout

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,7 @@ variable "webhook_lambda_timeout" {
 }
 
 variable "webhook_lambda_memory_size" {
-  description = "Allocated memory size of the webhook lambda in MB. 128 MB to 10,240 MB, in 1-MB increments." 
+  description = "Allocated memory size of the webhook lambda in MB. 128 MB to 10,240 MB, in 1-MB increments."
   type        = number
   default     = 128
 }

--- a/variables.tf
+++ b/variables.tf
@@ -99,6 +99,12 @@ variable "webhook_lambda_timeout" {
   default     = 10
 }
 
+variable "webhook_lambda_memory_size" {
+  description = "Allocated memory size of the webhook lambda in MB. 128 MB to 10,240 MB, in 1-MB increments." 
+  type        = number
+  default     = 128
+}
+
 variable "runners_lambda_zip" {
   description = "File location of the lambda zip file for scaling runners."
   type        = string


### PR DESCRIPTION
This adds variables and defaults, with descriptions, for memory size attributions to the webhook lambda used to process GH Actions requests.  

Closes  #2913 