### PR TITLE
fix(runners): Add missing entry for AWS-recommended price-capacity-optimized strategy to ProcessEnv interface

### DIFF
--- a/modules/runners/lambdas/runners/src/modules.d.ts
+++ b/modules/runners/lambdas/runners/src/modules.d.ts
@@ -20,6 +20,7 @@ declare namespace NodeJS {
     INSTANCE_MAX_SPOT_PRICE: string | undefined;
     INSTANCE_ALLOCATION_STRATEGY:
       | 'lowest-price'
+      | 'price-capacity-optimized'
       | 'diversified'
       | 'capacity-optimized'
       | 'capacity-optimized-prioritized';


### PR DESCRIPTION
Adds the strategy introduced in #2718 to the ProcessEnv of the `runners` lambda.