### PR TITLE
chore(readme): clarify cron expression in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ The pool is NOT enabled by default and can be enabled by setting at least one ob
 
 ### Idle runners
 
-The module will scale down to zero runners by default. By specifying a `idle_config` config, idle runners can be kept active. The scale down lambda checks if any of the cron expressions matches the current time with a margin of 5 seconds. When there is a match, the number of runners specified in the idle config will be kept active. In case multiple cron expressions matches, only the first one is taken into account. Below is an idle configuration for keeping runners active from 9 to 5 on working days.
+The module will scale down to zero runners by default. By specifying a `idle_config` config, idle runners can be kept active. The scale down lambda checks if any of the cron expressions matches the current time with a margin of 5 seconds. When there is a match, the number of runners specified in the idle config will be kept active. In case multiple cron expressions matches, only the first one is taken into account. Below is an idle configuration for keeping runners active from 9:00am to 5:59pm on working days. The [cron expression generator by Cronhub](https://crontab.cronhub.io/) is a great resource to set up your idle config.
 
 ```hcl
 idle_config = [{


### PR DESCRIPTION
Addresses the confusion in #1690 (I ran into the same mistake).