### PR TITLE
fix(runner): Adds InsufficientInstanceCapacity to list of scaling errors

### DIFF
--- a/modules/runners/lambdas/runners/src/aws/runners.ts
+++ b/modules/runners/lambdas/runners/src/aws/runners.ts
@@ -243,6 +243,7 @@ export async function createRunner(runnerParameters: RunnerInputParameters): Pro
       'ResourceLimitExceeded',
       'MaxSpotInstanceCountExceeded',
       'MaxSpotFleetRequestCountExceeded',
+      'InsufficientInstanceCapacity',
     ];
 
     if (errors.some((e) => scaleErrors.includes(e))) {


### PR DESCRIPTION
The ScaleUp lambda is dropping events when there is no capacity in the zone. This results in jobs being stalled and requiring manual cancellation.

This patch adds the `InsufficientInstanceCapacity` error code to the list of scale-up errors, allowing the built-in retry mechanism to pick up the error and not lose the event

See-Also: philips-labs/terraform-aws-github-runner#2925