### PR TITLE
fix: Allow lambda inside VPC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -306,6 +306,8 @@ module "runner_binaries" {
 
   lambda_subnet_ids         = var.lambda_subnet_ids
   lambda_security_group_ids = var.lambda_security_group_ids
+  aws_partition             = var.aws_partition
+  
 
   lambda_principals = var.lambda_principals
 }

--- a/main.tf
+++ b/main.tf
@@ -167,6 +167,7 @@ module "webhook" {
     
   lambda_subnet_ids         = var.lambda_subnet_ids
   lambda_security_group_ids = var.lambda_security_group_ids
+  aws_partition             = var.aws_partition
 
   log_type  = var.log_type
   log_level = var.log_level

--- a/main.tf
+++ b/main.tf
@@ -158,9 +158,9 @@ module "webhook" {
   logging_kms_key_id                            = var.logging_kms_key_id
 
   # labels
-  enable_workflow_job_labels_check = var.runner_enable_workflow_job_labels_check
-  workflow_job_labels_check_all    = var.runner_enable_workflow_job_labels_check_all
-  runner_labels                    = local.runner_labels
+  # enable_workflow_job_labels_check = var.runner_enable_workflow_job_labels_check
+  # workflow_job_labels_check_all    = var.runner_enable_workflow_job_labels_check_all
+  # runner_labels                    = local.runner_labels
   role_path                        = var.role_path
   role_permissions_boundary        = var.role_permissions_boundary
   repository_white_list            = var.repository_white_list

--- a/main.tf
+++ b/main.tf
@@ -157,9 +157,16 @@ module "webhook" {
   logging_retention_in_days                     = var.logging_retention_in_days
   logging_kms_key_id                            = var.logging_kms_key_id
 
-  role_path                 = var.role_path
-  role_permissions_boundary = var.role_permissions_boundary
-  repository_white_list     = var.repository_white_list
+  # labels
+  enable_workflow_job_labels_check = var.runner_enable_workflow_job_labels_check
+  workflow_job_labels_check_all    = var.runner_enable_workflow_job_labels_check_all
+  runner_labels                    = local.runner_labels
+  role_path                        = var.role_path
+  role_permissions_boundary        = var.role_permissions_boundary
+  repository_white_list            = var.repository_white_list
+    
+  lambda_subnet_ids         = var.lambda_subnet_ids
+  lambda_security_group_ids = var.lambda_security_group_ids
 
   log_type  = var.log_type
   log_level = var.log_level

--- a/main.tf
+++ b/main.tf
@@ -157,14 +157,10 @@ module "webhook" {
   logging_retention_in_days                     = var.logging_retention_in_days
   logging_kms_key_id                            = var.logging_kms_key_id
 
-  # labels
-  # enable_workflow_job_labels_check = var.runner_enable_workflow_job_labels_check
-  # workflow_job_labels_check_all    = var.runner_enable_workflow_job_labels_check_all
-  # runner_labels                    = local.runner_labels
-  role_path                        = var.role_path
-  role_permissions_boundary        = var.role_permissions_boundary
-  repository_white_list            = var.repository_white_list
-    
+  role_path                 = var.role_path
+  role_permissions_boundary = var.role_permissions_boundary
+  repository_white_list     = var.repository_white_list
+
   lambda_subnet_ids         = var.lambda_subnet_ids
   lambda_security_group_ids = var.lambda_security_group_ids
   aws_partition             = var.aws_partition
@@ -315,7 +311,7 @@ module "runner_binaries" {
   lambda_subnet_ids         = var.lambda_subnet_ids
   lambda_security_group_ids = var.lambda_security_group_ids
   aws_partition             = var.aws_partition
-  
+
 
   lambda_principals = var.lambda_principals
 }

--- a/modules/multi-runner/runner-binaries.tf
+++ b/modules/multi-runner/runner-binaries.tf
@@ -27,6 +27,10 @@ module "runner_binaries" {
   log_type  = var.log_type
   log_level = var.log_level
 
+  lambda_subnet_ids         = var.lambda_subnet_ids
+  lambda_security_group_ids = var.lambda_security_group_ids
+  aws_partition             = var.aws_partition
+
   lambda_principals = var.lambda_principals
 }
 locals {

--- a/modules/multi-runner/webhook.tf
+++ b/modules/multi-runner/webhook.tf
@@ -26,6 +26,10 @@ module "webhook" {
   role_permissions_boundary = var.role_permissions_boundary
   repository_white_list     = var.repository_white_list
 
+  lambda_subnet_ids         = var.lambda_subnet_ids
+  lambda_security_group_ids = var.lambda_security_group_ids
+  aws_partition             = var.aws_partition
+
   log_type  = var.log_type
   log_level = var.log_level
 }

--- a/modules/runner-binaries-syncer/README.md
+++ b/modules/runner-binaries-syncer/README.md
@@ -65,6 +65,7 @@ No modules.
 | [aws_iam_role_policy.lambda_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.lambda_syncer_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.syncer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.syncer_vpc_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.syncer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.on_deploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.syncer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
@@ -85,6 +86,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | (optional) partition for the base arn if not 'aws' | `string` | `"aws"` | no |
 | <a name="input_distribution_bucket_name"></a> [distribution\_bucket\_name](#input\_distribution\_bucket\_name) | Bucket for storing the action runner distribution. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | A name that identifies the environment, used as prefix and for tagging. | `string` | `null` | no |
 | <a name="input_lambda_architecture"></a> [lambda\_architecture](#input\_lambda\_architecture) | AWS Lambda architecture. Lambda functions using Graviton processors ('arm64') tend to have better price/performance than 'x86\_64' functions. | `string` | `"arm64"` | no |

--- a/modules/runner-binaries-syncer/runner-binaries-syncer.tf
+++ b/modules/runner-binaries-syncer/runner-binaries-syncer.tf
@@ -128,6 +128,12 @@ resource "aws_cloudwatch_event_target" "syncer" {
   arn  = aws_lambda_function.syncer.arn
 }
 
+resource "aws_iam_role_policy_attachment" "syncer_vpc_execution_role" {
+  count      = length(var.lambda_subnet_ids) > 0 ? 1 : 0
+  role       = aws_iam_role.syncer_lambda.name
+  policy_arn = "arn:${var.aws_partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
 resource "aws_lambda_permission" "syncer" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
@@ -173,3 +179,5 @@ resource "aws_lambda_permission" "on_deploy" {
   source_account = data.aws_caller_identity.current.account_id
   source_arn     = aws_s3_bucket.action_dist.arn
 }
+
+

--- a/modules/runner-binaries-syncer/variables.tf
+++ b/modules/runner-binaries-syncer/variables.tf
@@ -163,6 +163,12 @@ variable "lambda_security_group_ids" {
   default     = []
 }
 
+variable "aws_partition" {
+  description = "(optional) partition for the base arn if not 'aws'"
+  type        = string
+  default     = "aws"
+}
+
 variable "log_type" {
   description = "Logging format for lambda logging. Valid values are 'json', 'pretty', 'hidden'. "
   type        = string

--- a/modules/webhook/README.md
+++ b/modules/webhook/README.md
@@ -67,6 +67,7 @@ No modules.
 | [aws_iam_role_policy.webhook_sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.webhook_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.webhook_workflow_job_sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.webhook_vpc_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_iam_policy_document.lambda_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -75,12 +76,15 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | (optional) partition for the base arn if not 'aws' | `string` | `"aws"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | A name that identifies the environment, used as prefix and for tagging. | `string` | `null` | no |
 | <a name="input_github_app_parameters"></a> [github\_app\_parameters](#input\_github\_app\_parameters) | Parameter Store for GitHub App Parameters. | <pre>object({<br>    webhook_secret = map(string)<br>  })</pre> | n/a | yes |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | Optional CMK Key ARN to be used for Parameter Store. | `string` | `null` | no |
 | <a name="input_lambda_architecture"></a> [lambda\_architecture](#input\_lambda\_architecture) | AWS Lambda architecture. Lambda functions using Graviton processors ('arm64') tend to have better price/performance than 'x86\_64' functions. | `string` | `"arm64"` | no |
 | <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | AWS Lambda runtime. | `string` | `"nodejs18.x"` | no |
 | <a name="input_lambda_s3_bucket"></a> [lambda\_s3\_bucket](#input\_lambda\_s3\_bucket) | S3 bucket from which to specify lambda functions. This is an alternative to providing local files directly. | `string` | `null` | no |
+| <a name="input_lambda_security_group_ids"></a> [lambda\_security\_group\_ids](#input\_lambda\_security\_group\_ids) | List of security group IDs associated with the Lambda function. | `list(string)` | `[]` | no |
+| <a name="input_lambda_subnet_ids"></a> [lambda\_subnet\_ids](#input\_lambda\_subnet\_ids) | List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_id`. | `list(string)` | `[]` | no |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Time out of the lambda in seconds. | `number` | `10` | no |
 | <a name="input_lambda_zip"></a> [lambda\_zip](#input\_lambda\_zip) | File location of the lambda zip file. | `string` | `null` | no |
 | <a name="input_log_level"></a> [log\_level](#input\_log\_level) | Logging level for lambda logging. Valid values are  'silly', 'trace', 'debug', 'info', 'warn', 'error', 'fatal'. | `string` | `"info"` | no |

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -1,8 +1,3 @@
-variable "aws_region" {
-  description = "AWS region."
-  type        = string
-}
-
 variable "lambda_subnet_ids" {
   description = "List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_id`."
   type        = list(string)

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -171,6 +171,12 @@ variable "lambda_runtime" {
   default     = "nodejs18.x"
 }
 
+variable "aws_partition" {
+  description = "(optional) partition for the base arn if not 'aws'"
+  type        = string
+  default     = "aws"
+}
+
 variable "lambda_architecture" {
   description = "AWS Lambda architecture. Lambda functions using Graviton processors ('arm64') tend to have better price/performance than 'x86_64' functions. "
   type        = string

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -1,3 +1,20 @@
+variable "aws_region" {
+  description = "AWS region."
+  type        = string
+}
+
+variable "lambda_subnet_ids" {
+  description = "List of subnets in which the action runners will be launched, the subnets needs to be subnets in the `vpc_id`."
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_security_group_ids" {
+  description = "List of security group IDs associated with the Lambda function."
+  type        = list(string)
+  default     = []
+}
+
 variable "environment" {
   description = "A name that identifies the environment, used as prefix and for tagging."
   type        = string

--- a/modules/webhook/webhook.tf
+++ b/modules/webhook/webhook.tf
@@ -22,6 +22,14 @@ resource "aws_lambda_function" "webhook" {
       SQS_WORKFLOW_JOB_QUEUE              = try(var.sqs_workflow_job_queue, null) != null ? var.sqs_workflow_job_queue.id : ""
     }
   }
+  
+  dynamic "vpc_config" {
+    for_each = var.lambda_subnet_ids != null && var.lambda_security_group_ids != null ? [true] : []
+    content {
+      security_group_ids = var.lambda_security_group_ids
+      subnet_ids         = var.lambda_subnet_ids
+    }
+  }
 
   tags = var.tags
 }
@@ -66,6 +74,12 @@ resource "aws_iam_role_policy" "webhook_logging" {
   policy = templatefile("${path.module}/policies/lambda-cloudwatch.json", {
     log_group_arn = aws_cloudwatch_log_group.webhook.arn
   })
+}
+
+resource "aws_iam_role_policy_attachment" "webhook_vpc_execution_role" {
+  count      = length(var.lambda_subnet_ids) > 0 ? 1 : 0
+  role       = aws_iam_role.webhook_lambda.name
+  policy_arn = "arn:${var.aws_partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_iam_role_policy" "webhook_sqs" {

--- a/modules/webhook/webhook.tf
+++ b/modules/webhook/webhook.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "webhook" {
       SQS_WORKFLOW_JOB_QUEUE              = try(var.sqs_workflow_job_queue, null) != null ? var.sqs_workflow_job_queue.id : ""
     }
   }
-  
+
   dynamic "vpc_config" {
     for_each = var.lambda_subnet_ids != null && var.lambda_security_group_ids != null ? [true] : []
     content {


### PR DESCRIPTION
Hi! 👋

This PR contains the following changes:
-  It allows webhook lambda to run inside a VPC 
-  fix a minor issue in the syncer module, when the lambda is running inside vpc AWSLambdaVPCAccessExecutionRole needs to be attached.

Updated doc.

Do not hesitate to ask if you need further details,
Thanks!