### PR TITLE
fix(runners): Fix typo in .setup_info generated in start-runner.ps1.

### DIFF
--- a/modules/runners/templates/start-runner.ps1
+++ b/modules/runners/templates/start-runner.ps1
@@ -100,7 +100,7 @@ Write-Host "Starting the runner as user $run_as"
 $jsonBody = @(
     @{
         group='Runner Image'
-        details="AMI id: $ami_id"
+        detail="AMI id: $ami_id"
     }
 )
 ConvertTo-Json -InputObject $jsonBody | Set-Content -Path "$pwd\.setup_info"


### PR DESCRIPTION
Another small typo in `start-runner.ps1`, this time making the AMI id fail to appear in the "Set up job" section of the workflow log.

See the bash version of the same script, which doesn't have the typo:
https://github.com/philips-labs/terraform-aws-github-runner/blob/ef548d93e7d61b3ae3e6743a3f9d8b58ba4ee5cc/modules/runners/templates/start-runner.sh#L82

And also the GitHub Actions Runner docs, where it says it's `detail` not `details`:
https://github.com/actions/runner/blob/main/docs/adrs/0354-runner-machine-info.md

By the way, I've also modified this section of the code in our local fork to include the EC2 instance type along the the AMI ID, which is very useful because our jobs are allowed to run on a long list of different instance types. It looks like this:

![image](https://user-images.githubusercontent.com/924374/220086972-fccfac6f-ea97-47de-aecc-5ad1527f34d0.png)

Note the new "Instance Type" field. Let me know if you would like a PR for that change as well.