### PR TITLE
fix: enforce overwrite to ssm parameter

### DIFF
--- a/modules/multi-runner/runners.tf
+++ b/modules/multi-runner/runners.tf
@@ -64,7 +64,7 @@ module "runners" {
   logging_retention_in_days        = var.logging_retention_in_days
   logging_kms_key_id               = var.logging_kms_key_id
   enable_cloudwatch_agent          = each.value.runner_config.enable_cloudwatch_agent
-  cloudwatch_config                = var.cloudwatch_config
+  cloudwatch_config                = each.value.runner_config.cloudwatch_config
   runner_log_files                 = each.value.runner_config.runner_log_files
   runner_group_name                = each.value.runner_config.runner_group_name
 

--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -65,6 +65,7 @@ variable "multi_runner_config" {
       userdata_template                       = optional(string, null)
       enable_runner_detailed_monitoring       = optional(bool, false)
       enable_cloudwatch_agent                 = optional(bool, true)
+      cloudwatch_config                       = optional(string, null)
       userdata_pre_install                    = optional(string, "")
       userdata_post_install                   = optional(string, "")
       runner_ec2_tags                         = optional(map(string), {})
@@ -448,12 +449,6 @@ variable "lambda_security_group_ids" {
   description = "List of security group IDs associated with the Lambda function."
   type        = list(string)
   default     = []
-}
-
-variable "cloudwatch_config" {
-  description = "(optional) Replaces the module default cloudwatch log config. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html for details."
-  type        = string
-  default     = null
 }
 
 variable "instance_profile_path" {

--- a/modules/runners/logging.tf
+++ b/modules/runners/logging.tf
@@ -47,7 +47,8 @@ resource "aws_ssm_parameter" "cloudwatch_agent_config_runner" {
   value = var.cloudwatch_config != null ? var.cloudwatch_config : templatefile("${path.module}/templates/cloudwatch_config.json", {
     logfiles = jsonencode(local.logfiles)
   })
-  tags = local.tags
+  overwrite = true
+  tags      = local.tags
 }
 
 resource "aws_cloudwatch_log_group" "gh_runners" {


### PR DESCRIPTION
fix : SSM parameter "cloudwatch_agent_config_runner" not updating (add overwrite to ssm parameter)