### PR TITLE
fix: Add missing IAM permissions for runners from encrypted AMI

### DIFF
--- a/modules/runners/policies/lambda-scale-up.json
+++ b/modules/runners/policies/lambda-scale-up.json
@@ -63,6 +63,18 @@
                 "kms:Decrypt"
             ],
             "Resource": "${ami_kms_key_arn}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:CreateGrant"
+            ],
+            "Resource": "${ami_kms_key_arn}",
+            "Condition": {
+                "Bool": {
+                    "aws:ViaAWSService": "true"
+                }
+            }
 %{ endif ~}
         }
     ]

--- a/modules/runners/pool/policies/lambda-pool.json
+++ b/modules/runners/pool/policies/lambda-pool.json
@@ -54,6 +54,18 @@
                 "kms:Decrypt"
             ],
             "Resource": "${ami_kms_key_arn}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:CreateGrant"
+            ],
+            "Resource": "${ami_kms_key_arn}",
+            "Condition": {
+                "Bool": {
+                    "aws:ViaAWSService": "true"
+                }
+            }
 %{ endif ~}
         }
     ]


### PR DESCRIPTION
This should fix missing IAM permissions when running from encrypted AMI. See [this issue](https://github.com/philips-labs/terraform-aws-github-runner/issues/2927)