### PR TITLE
fix: allow the instances to send metrics

### DIFF
--- a/modules/setup-iam-permissions/policies/boundary.json
+++ b/modules/setup-iam-permissions/policies/boundary.json
@@ -13,7 +13,8 @@
         "resource-groups:*",
         "ssm:*",
         "ssmmessages:*",
-        "ec2messages:*"
+        "ec2messages:*",
+        "cloudwatch:*"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
This is needed in order to be able to send metrics around the disk and memory. Those were getting a 403 until this update was made.

Example error in the Cloudwatch agent logs:
```
not authorized to perform: cloudwatch:PutMetricData because no permissions boundary allows the cloudwatch:PutMetricData action
        status code: 403, request id: 
```