### PR TITLE
fix(webhook): add required permission to SQS message producer

### DIFF
--- a/modules/webhook/policies/lambda-ssm.json
+++ b/modules/webhook/policies/lambda-ssm.json
@@ -14,7 +14,8 @@
     {
         "Effect": "Allow",
         "Action": [
-            "kms:Decrypt"
+            "kms:Decrypt",
+            "kms:GenerateDataKey"
         ],
         "Resource": "${kms_key_arn}"
     %{ endif ~}


### PR DESCRIPTION
Thank you for your Terraform module. It has been of great help!

I have encountered one issue with setting the SQS queue to use KMS encryption with a CMK. I think that the webhook lambda should have the `kms:GenerateDataKey` action allowed as it's acting as a producer, see here:
see additional details here https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-key-management.html#sqs-what-permissions-for-sse.

In my test, without this additional configuration the lambda times-out with the default of 10 seconds. Adding this to the policy allows me to use a KMS-encrypted queue with a CMK.

Please let me know if there's anything else I should do.