### PR TITLE
fix(images): Changed windows base image to Windows_Server-2022-English-Full-ECS_Optimize*

### DIFF
--- a/images/windows-core-2022/github_agent.windows.pkr.hcl
+++ b/images/windows-core-2022/github_agent.windows.pkr.hcl
@@ -65,7 +65,7 @@ source "amazon-ebs" "githubrunner" {
 
   source_ami_filter {
     filters = {
-      name                = "Windows_Server-2022-English-Core-ContainersLatest-**"
+      name                = "Windows_Server-2022-English-Full-ECS_Optimized-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }


### PR DESCRIPTION
As per AWS announcment, the current Windows base image is using Docker EE which is now sold and managed MCR under s paid subscription model. This change results in the current base image using old unmaintained version of docker even with the latest Windows base image. 

To fix this shortcoming, we are replacing the base image with ECS optimized image using Docker CE and which supposedly is better managed than the current one.