### PR TITLE
chore(ci): fix tf-docs on PR

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,10 +1,12 @@
 name: Update docs
 on:
   push:
-    branches:
-      - release-please--branches--main
-  pull_request:
-
+    branches-ignore:
+      - main
+    paths:
+      - "*.tf"
+      - "*.md"
+      - ".github/workflows/update-docs.yml"
 permissions: read-all
 jobs:
   docs:
@@ -14,12 +16,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - if: github.event_name == 'pull_request'
-        name: Checkout PR
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-
       - if: github.event_name == 'push'
         name: Checkout branch
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
@@ -29,4 +25,14 @@ jobs:
         with:
           find-dir: .
           git-commit-message: "docs: auto update terraform docs"
-          git-push: true
+          git-push: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Create Pull Request (main branch only)
+        if: github.ref == 'refs/heads/main'
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # ratchet:peter-evans/create-pull-request@v4.2.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update Terraform docs"
+          title: "docs: Update Terraform docs"
+          branch: ${{ github.event.pull_request.base.ref }}-update-docs
+          base: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,8 +1,6 @@
 name: Update docs
 on:
   push:
-    branches-ignore:
-      - main
     paths:
       - "*.tf"
       - "*.md"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,9 @@ If your issue appears to be a bug, and hasn't been reported, open a new issue. H
 
 **If you get help, help others. Good karma rulez!**
 
-### Submitting a Merge Request
+### Submitting a Pull Request
 
-Before you submit your merge request consider the following guidelines:
+Before you submit your pull request consider the following guidelines:
 
 * Make your changes in a new git branch:
 
@@ -63,7 +63,8 @@ Before you submit your merge request consider the following guidelines:
 
 * Create your patch, **including appropriate test cases**.
 * Install [Terraform](https://www.terraform.io/). We lock the version with [tvenv](https://github.com/tfutils/tfenv), check `required_version` in `versions.tf` for the current development version of the module.
-* Install [pre-commit hooks](https://pre-commit.com/). The hooks runs some basic checks and update the docs. The commit will run the hooks, you can invoke the hooks manually `pre-commit run --all-files` as well.
+* Install [pre-commit hooks](https://pre-commit.com/). The hooks runs some basic checks. The commit will run the hooks, you can invoke the hooks manually `pre-commit run --all-files` as well.
+* For updating docs, you have to enable GitHub actions on your forked repository. Simply go to the tab Actions and enable actions.
 * Commit your changes using a descriptive commit message.
 
     ```shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Before you submit your pull request consider the following guidelines:
     ```
 
 * Create your patch, **including appropriate test cases**.
-* Install [Terraform](https://www.terraform.io/). We lock the version with [tvenv](https://github.com/tfutils/tfenv), check `required_version` in `versions.tf` for the current development version of the module.
+* Install [Terraform](https://www.terraform.io/). We lock the version with [tfenv](https://github.com/tfutils/tfenv), check `required_version` in `versions.tf` for the current development version of the module.
 * Install [pre-commit hooks](https://pre-commit.com/). The hooks runs some basic checks. The commit will run the hooks, you can invoke the hooks manually `pre-commit run --all-files` as well.
 * For updating docs, you have to enable GitHub actions on your forked repository. Simply go to the tab Actions and enable actions.
 * Commit your changes using a descriptive commit message.

--- a/README.md
+++ b/README.md
@@ -595,6 +595,13 @@ We welcome any improvement to the standard module to make the default as secure 
 
 ## Outputs
 
+| Name | Description |
+|------|-------------|
+| <a name="output_binaries_syncer"></a> [binaries\_syncer](#output\_binaries\_syncer) | n/a |
+| <a name="output_queues"></a> [queues](#output\_queues) | SQS queues. |
+| <a name="output_runners"></a> [runners](#output\_runners) | n/a |
+| <a name="output_ssm_parameters"></a> [ssm\_parameters](#output\_ssm\_parameters) | n/a |
+| <a name="output_webhook"></a> [webhook](#output\_webhook) | n/a |
 <!-- END_TF_DOCS -->
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ This [Terraform](https://www.terraform.io/) module creates the required infrastr
 - [Logging](#logging)
 - [Debugging](#debugging)
 - [Security Consideration](#security-consideration)
+- [Requirements](#requirements)
+- [Providers](#providers)
+- [Modules](#modules)
+- [Resources](#resources)
+- [Inputs](#inputs)
+- [Outputs](#outputs)
 - [Contribution](#contribution)
 - [Philips Forest](#philips-forest)
 
@@ -589,13 +595,6 @@ We welcome any improvement to the standard module to make the default as secure 
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_binaries_syncer"></a> [binaries\_syncer](#output\_binaries\_syncer) | n/a |
-| <a name="output_queues"></a> [queues](#output\_queues) | SQS queues. |
-| <a name="output_runners"></a> [runners](#output\_runners) | n/a |
-| <a name="output_ssm_parameters"></a> [ssm\_parameters](#output\_ssm\_parameters) | n/a |
-| <a name="output_webhook"></a> [webhook](#output\_webhook) | n/a |
 <!-- END_TF_DOCS -->
 
 ## Contribution

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -6,13 +6,6 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
-## Modules
-
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.16.0 |
-
-## Resources
 
 | Name | Type |
 |------|------|

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -6,6 +6,19 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.16.0 |
+
+## Resources
 
 | Name | Type |
 |------|------|

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -6,12 +6,6 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
-
 ## Modules
 
 | Name | Source | Version |


### PR DESCRIPTION
We moved recently to generate Terrafom docs on the release branch. However it would be nice to have up-to-date docs on the main branch. In the past we used pre-commit. But requires a contributor have local tools setup. Keeping pre-commit and the tf-dcos action creates a conflict.

This PR will address the issues and introducee a sub optimal solution. I could not find an option to update from a Pull Request trigger the source repo or suggest the change via a PR. 

The solution in this PR
- Run the workflow on every branch
- For the main branch (protected) create a PR

Looking up if a branch is protected is possible via the API, but this API call is not allowed by the GitHub action token. It requires a personal token with more permission. 

To run the wofklow on forks, the forked repo needs to enable action. If not enabled nothing will stop conribution. Once merged. Either via a PR the main will be updated with the docs. Or via the release branch.

@koendelaat @mcaulifn any suggestion are welcome





