### PR TITLE
fix(multi-runner):  convertdistribution_bucket_name to lowercase

### DIFF
--- a/modules/multi-runner/runner-binaries.tf
+++ b/modules/multi-runner/runner-binaries.tf
@@ -4,7 +4,8 @@ module "runner_binaries" {
   prefix   = "${var.prefix}-${each.value.os_type}-${each.value.architecture}"
   tags     = local.tags
 
-  distribution_bucket_name = "${var.prefix}-${each.value.os_type}-${each.value.architecture}-dist-${random_string.random.result}"
+  # force mandatory lower case for s3 bucketname
+  distribution_bucket_name = lower("${var.prefix}-${each.value.os_type}-${each.value.architecture}-dist-${random_string.random.result}")
 
   runner_os           = each.value.os_type
   runner_architecture = each.value.architecture


### PR DESCRIPTION
This is a mandatory spec.

At my company, we have some forcing capital letter prefix conventions and we are using the var.prefix for that. But the bucket name you can not use capital letters. I had to patch your module like that in order to work. I am assuming this is a harmless change that you can take advantage of that.