### PR TITLE
fix: Remove deprecated use of S3 ACLs

### DIFF
--- a/modules/runner-binaries-syncer/main.tf
+++ b/modules/runner-binaries-syncer/main.tf
@@ -9,7 +9,7 @@ resource "aws_s3_bucket" "action_dist" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "this" {
-  bucket   = aws_s3_bucket.action_dist.id
+  bucket = aws_s3_bucket.action_dist.id
   rule {
     object_ownership = "BucketOwnerEnforced"
   }

--- a/modules/runner-binaries-syncer/main.tf
+++ b/modules/runner-binaries-syncer/main.tf
@@ -8,9 +8,11 @@ resource "aws_s3_bucket" "action_dist" {
   tags          = var.tags
 }
 
-resource "aws_s3_bucket_acl" "action_dist_acl" {
-  bucket = aws_s3_bucket.action_dist.id
-  acl    = "private"
+resource "aws_s3_bucket_ownership_controls" "this" {
+  bucket   = aws_s3_bucket.action_dist.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "bucket-config" {


### PR DESCRIPTION
ACLs were disabled by default in April 2023:
https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/

As we don't use ACLs, it's simplest to configure the bucket to not use them, which is the new recommended approach.

Fixes #3202.