### PR TITLE
fix: Retry aws metadata token download

### DIFF
--- a/modules/runners/templates/start-runner.ps1
+++ b/modules/runners/templates/start-runner.ps1
@@ -3,25 +3,38 @@
 
 Write-Host  "Retrieving TOKEN from AWS API"
 $token=Invoke-RestMethod -Method PUT -Uri "http://169.254.169.254/latest/api/token" -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "180"}
+if ( ! $token ) {
+  $retrycount=0
+  do {
+    echo "Failed to retrieve token. Retrying in 5 seconds."
+    Start-Sleep 5
+    $token=Invoke-RestMethod -Method PUT -Uri "http://169.254.169.254/latest/api/token" -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "180"}
+    $retrycount=$retrycount + 1
+    if ( $retrycount -gt 40 )
+    {
+        break
+    }
+  } until ($token)
+}
 
 $ami_id=Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/ami-id" -Headers @{"X-aws-ec2-metadata-token" = $token}
 
 $metadata=Invoke-RestMethod -Uri "http://169.254.169.254/latest/dynamic/instance-identity/document" -Headers @{"X-aws-ec2-metadata-token" = $token}
 
 $Region = $metadata.region
-Write-Host  "Reteieved REGION from AWS API ($Region)"
+Write-Host  "Retrieved REGION from AWS API ($Region)"
 
 $InstanceId = $metadata.instanceId
-Write-Host  "Reteieved InstanceId from AWS API ($InstanceId)"
+Write-Host  "Retrieved InstanceId from AWS API ($InstanceId)"
 
 $tags=aws ec2 describe-tags --region "$Region" --filters "Name=resource-id,Values=$InstanceId" | ConvertFrom-Json
 Write-Host  "Retrieved tags from AWS API"
 
 $environment=$tags.Tags.where( {$_.Key -eq 'ghr:environment'}).value
-Write-Host  "Reteieved ghr:environment tag - ($environment)"
+Write-Host  "Retrieved ghr:environment tag - ($environment)"
 
 $runner_name_prefix=$tags.Tags.where( {$_.Key -eq 'ghr:runner_name_prefix'}).value
-Write-Host  "Reteieved ghr:runner_name_prefix tag - ($runner_name_prefix)"
+Write-Host  "Retrieved ghr:runner_name_prefix tag - ($runner_name_prefix)"
 
 $ssm_config_path=$tags.Tags.where( {$_.Key -eq 'ghr:ssm_config_path'}).value
 Write-Host  "Retrieved ghr:ssm_config_path tag - ($ssm_config_path)"

--- a/modules/runners/templates/start-runner.sh
+++ b/modules/runners/templates/start-runner.sh
@@ -3,7 +3,7 @@
 ## Retrieve instance metadata
 
 echo "Retrieving TOKEN from AWS API"
-token=$(curl -f -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 180")
+token=$(curl --retry 20 -f -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 180")
 
 ami_id=$(curl -f -H "X-aws-ec2-metadata-token: $token" -v http://169.254.169.254/latest/meta-data/ami-id)
 


### PR DESCRIPTION
Testing Windows 2019 using multi-runner and these image scripts https://github.com/philips-labs/terraform-aws-github-runner/tree/main/images/windows-core-2019 . Installed a number of [choco packages](https://chocolatey.org/) in the AMI such as cmake, python, curl, visual studio. Ran github actions. Most of the time, the windows 2019 runners would be launched but never actually process any jobs. The jobs would be frozen forever.

Log into the server and checked runner-startup.log. Here is the output:

```
Retrieving TOKEN from AWS API
PS>TerminatingError(Invoke-RestMethod): "Unable to connect to the remote server"
Invoke-RestMethod : Unable to connect to the remote server
At C:\start-runner.ps1:21 char:8
+ $token=Invoke-RestMethod -Method PUT -Uri "http://169.254.169.254/lat ...
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-RestMethod],
WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand
Invoke-RestMethod : Unable to connect to the remote server
At C:\start-runner.ps1:21 char:8
+ $token=Invoke-RestMethod -Method PUT -Uri "http://169.254.169.254/lat ...
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-RestMethod], WebExc
   eption
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand

>> TerminatingError(Invoke-RestMethod): "Object reference not set to an instance of an object."
Invoke-RestMethod : Object reference not set to an instance of an object.
At C:\start-runner.ps1:23 char:9
+ $ami_id=Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-da ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Invoke-RestMethod], NullReferenceException
    + FullyQualifiedErrorId : System.NullReferenceException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand
Invoke-RestMethod : Object reference not set to an instance of an object.
At C:\start-runner.ps1:23 char:9
+ $ami_id=Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-da ...

```

What's happening is it fails to retrieve the aws metadata token on the first attempt, and then all subsequent actions fail.

The solution was to add a retry when requesting the metadata token. This fixed the problem.

For other operating systems besides Windows 2019, even if they usually succeed, adding a retry doesn't hurt anything, and helps in case there are any random connection failures.

