### PR TITLE
fix: Use runner name instead of instance ID when determining pool runner count

### DIFF
--- a/lambdas/functions/control-plane/src/aws/runners.d.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.d.ts
@@ -9,6 +9,7 @@ export interface RunnerList {
   type?: string;
   repo?: string;
   org?: string;
+  runnerName: string;
 }
 
 export interface RunnerInfo {
@@ -16,6 +17,7 @@ export interface RunnerInfo {
   launchTime?: Date;
   owner: string;
   type: string;
+  runnerName: string;
 }
 
 export interface ListRunnerFilters {

--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -153,6 +153,7 @@ describe('terminate runner', () => {
       instanceId: 'instance-2',
       owner: 'owner-2',
       type: 'Repo',
+      runnerName: 'instance-2',
     };
     await terminateRunner(runner.instanceId);
 

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -83,6 +83,7 @@ function getRunnerInfo(runningInstances: DescribeInstancesResult) {
             type: i.Tags?.find((e) => e.Key === 'Type')?.Value as string,
             repo: i.Tags?.find((e) => e.Key === 'Repo')?.Value as string,
             org: i.Tags?.find((e) => e.Key === 'Org')?.Value as string,
+            runnerName: "".concat(i.Tags?.find((e) => e.Key === "ghr:runner_name_prefix")?.Value as string || "", i.InstanceId as string),
           });
         }
       }

--- a/lambdas/functions/control-plane/src/pool/pool.test.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.test.ts
@@ -49,18 +49,21 @@ const ec2InstancesRegistered = [
     launchTime: new Date(),
     type: 'Org',
     owner: ORG,
+    runnerName: 'i-1-idle',
   },
   {
     instanceId: 'i-2-busy',
     launchTime: new Date(),
     type: 'Org',
     owner: ORG,
+    runnerName: 'i-2-busy',
   },
   {
     instanceId: 'i-3-offline',
     launchTime: new Date(),
     type: 'Org',
     owner: ORG,
+    runnerName: 'i-3-offline',
   },
   {
     instanceId: 'i-4-idle-older-than-minimum-time-running',
@@ -69,6 +72,7 @@ const ec2InstancesRegistered = [
       .toDate(),
     type: 'Org',
     owner: ORG,
+    runnerName: 'i-4-idle-older-than-minimum-time-running',
   },
 ];
 
@@ -190,6 +194,7 @@ describe('Test simple pool.', () => {
             .toDate(),
           type: 'Org',
           owner: ORG,
+          runnerName: 'i-4-still-booting',
         },
         {
           instanceId: 'i-5-orphan',
@@ -198,6 +203,7 @@ describe('Test simple pool.', () => {
             .toDate(),
           type: 'Org',
           owner: ORG,
+          runnerName: 'i-5-orphan',
         },
       ]);
 
@@ -220,6 +226,7 @@ describe('Test simple pool.', () => {
             .toDate(),
           type: 'Org',
           owner: ORG,
+          runnerName: 'i-4-still-booting',
         },
         {
           instanceId: 'i-5-orphan',
@@ -228,6 +235,7 @@ describe('Test simple pool.', () => {
             .toDate(),
           type: 'Org',
           owner: ORG,
+          runnerName: 'i-5-orphan',
         },
       ]);
 

--- a/lambdas/functions/control-plane/src/pool/pool.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.ts
@@ -68,19 +68,19 @@ export async function adjust(event: PoolEvent): Promise<void> {
   let numberOfRunnersInPool = 0;
   for (const ec2Instance of ec2runners) {
     if (
-      runnerStatus.get(ec2Instance.instanceId)?.busy === false &&
-      runnerStatus.get(ec2Instance.instanceId)?.status === 'online'
+      runnerStatus.get(ec2Instance.runnerName)?.busy === false &&
+      runnerStatus.get(ec2Instance.runnerName)?.status === 'online'
     ) {
       numberOfRunnersInPool++;
-      logger.debug(`Runner ${ec2Instance.instanceId} is idle in GitHub and counted as part of the pool`);
-    } else if (runnerStatus.get(ec2Instance.instanceId) != null) {
-      logger.debug(`Runner ${ec2Instance.instanceId} is not idle in GitHub and NOT counted as part of the pool`);
+      logger.debug(`Runner ${ec2Instance.runnerName} is idle in GitHub and counted as part of the pool`);
+    } else if (runnerStatus.get(ec2Instance.runnerName) != null) {
+      logger.debug(`Runner ${ec2Instance.runnerName} is not idle in GitHub and NOT counted as part of the pool`);
     } else if (!bootTimeExceeded(ec2Instance)) {
       numberOfRunnersInPool++;
-      logger.info(`Runner ${ec2Instance.instanceId} is still booting and counted as part of the pool`);
+      logger.info(`Runner ${ec2Instance.runnerName} is still booting and counted as part of the pool`);
     } else {
       logger.debug(
-        `Runner ${ec2Instance.instanceId} is not idle in GitHub nor booting and not counted as part of the pool`,
+        `Runner ${ec2Instance.runnerName} is not idle in GitHub nor booting and not counted as part of the pool`,
       );
     }
   }

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -123,6 +123,7 @@ beforeEach(() => {
       launchTime: new Date(),
       type: 'Org',
       owner: TEST_DATA.repositoryOwner,
+      runnerName: 'i-1234',
     },
   ]);
 


### PR DESCRIPTION
The logic for determining the current pool runner count was using a map that uses runner names as the key. It would then attempt to get from that map using EC2 instance IDs, however this would never find the runners if there was a runner prefix used. 