### PR TITLE
feat(syncer): update bucket policy to require ssl

### DIFF
--- a/modules/runner-binaries-syncer/main.tf
+++ b/modules/runner-binaries-syncer/main.tf
@@ -79,38 +79,52 @@ resource "aws_s3_bucket_versioning" "action_dist" {
   }
 }
 
-data "aws_iam_policy_document" "action_dist_sse_policy" {
-  count = try(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default, null) != null ? 1 : 0
-
+data "aws_iam_policy_document" "action_dist_bucket_policy" {
   statement {
-    effect = "Deny"
+    sid       = "ForceSSLOnlyAccess"
+    effect    = "Deny"
+    actions   = ["s3:*"]
+    resources = [aws_s3_bucket.action_dist.arn, "${aws_s3_bucket.action_dist.arn}/*"]
 
     principals {
-      type = "AWS"
-
-      identifiers = [
-        "*",
-      ]
+      identifiers = ["*"]
+      type        = "*"
     }
 
-    actions = [
-      "s3:PutObject",
-    ]
-
-    resources = [
-      "${aws_s3_bucket.action_dist.arn}/*",
-    ]
-
     condition {
-      test     = "StringNotEquals"
-      variable = "s3:x-amz-server-side-encryption"
-      values   = [var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm]
+      test     = "Bool"
+      values   = ["false"]
+      variable = "aws:SecureTransport"
+    }
+  }
+
+  dynamic "statement" {
+    for_each = try(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default, null) != null ? [true] : []
+
+    content {
+      sid       = "ForceSSE"
+      effect    = "Deny"
+      actions   = ["s3:PutObject"]
+      resources = ["${aws_s3_bucket.action_dist.arn}/*"]
+
+      principals {
+        type = "AWS"
+
+        identifiers = [
+          "*",
+        ]
+      }
+
+      condition {
+        test     = "StringNotEquals"
+        variable = "s3:x-amz-server-side-encryption"
+        values   = [var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm]
+      }
     }
   }
 }
 
-resource "aws_s3_bucket_policy" "action_dist_sse_policy" {
-  count  = try(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default, null) != null ? 1 : 0
+resource "aws_s3_bucket_policy" "action_dist_bucket_policy" {
   bucket = aws_s3_bucket.action_dist.id
-  policy = data.aws_iam_policy_document.action_dist_sse_policy[0].json
+  policy = data.aws_iam_policy_document.action_dist_bucket_policy.json
 }


### PR DESCRIPTION
This change will update bucket policy to always require SSL interaction, as reported in #3277. With this change, the module will always create and attach a bucket policy. However, the previous optional force SSE policy still remains optional.  