### PR TITLE
fix: add more outputs to multi runners module.

### DIFF
--- a/modules/multi-runner/outputs.tf
+++ b/modules/multi-runner/outputs.tf
@@ -1,4 +1,24 @@
 output "runners" {
+  value = [for runner in module.runners : {
+    launch_template_name    = runner.launch_template.name
+    launch_template_id      = runner.launch_template.id
+    launch_template_version = runner.launch_template.latest_version
+    launch_template_ami_id  = runner.launch_template.image_id
+    lambda_up               = runner.lambda_scale_up
+    lambda_up_log_group     = runner.lambda_scale_up_log_group
+    lambda_down             = runner.lambda_scale_down
+    lambda_down_log_group   = runner.lambda_scale_down_log_group
+    lambda_pool             = runner.lambda_pool
+    lambda_pool_log_group   = runner.lambda_pool_log_group
+    role_runner             = runner.role_runner
+    role_scale_up           = runner.role_scale_up
+    role_scale_down         = runner.role_scale_down
+    role_pool               = runner.role_pool
+    runners_log_groups      = runner.runners_log_groups
+    logfiles                = runner.logfiles
+  }]
+}
+output "runners_map" {
   value = { for runner_key, runner in module.runners : runner_key => {
     launch_template_name    = runner.launch_template.name
     launch_template_id      = runner.launch_template.id
@@ -21,6 +41,16 @@ output "runners" {
 }
 
 output "binaries_syncer" {
+  value = [for runner_binary in module.runner_binaries : {
+    lambda           = runner_binary.lambda
+    lambda_log_group = runner_binary.lambda_log_group
+    lambda_role      = runner_binary.lambda_role
+    location         = "s3://runner_binary.bucket.id}/runner_binary.bucket.key"
+    bucket           = runner_binary.bucket
+  }]
+}
+
+output "binaries_syncer_map" {
   value = { for runner_binary_key, runner_binary in module.runner_binaries : runner_binary_key => {
     lambda           = runner_binary.lambda
     lambda_log_group = runner_binary.lambda_log_group

--- a/modules/multi-runner/outputs.tf
+++ b/modules/multi-runner/outputs.tf
@@ -1,5 +1,5 @@
 output "runners" {
-  value = [for runner in module.runners : {
+  value = { for runner_key, runner in module.runners : runner_key => {
     launch_template_name    = runner.launch_template.name
     launch_template_id      = runner.launch_template.id
     launch_template_version = runner.launch_template.latest_version
@@ -16,7 +16,8 @@ output "runners" {
     role_pool               = runner.role_pool
     runners_log_groups      = runner.runners_log_groups
     logfiles                = runner.logfiles
-  }]
+    }
+  }
 }
 
 output "binaries_syncer" {

--- a/modules/multi-runner/outputs.tf
+++ b/modules/multi-runner/outputs.tf
@@ -21,13 +21,13 @@ output "runners" {
 }
 
 output "binaries_syncer" {
-  value = [for runner_binary in module.runner_binaries : {
+  value = { for runner_binary_key, runner_binary in module.runner_binaries : runner_binary_key => {
     lambda           = runner_binary.lambda
     lambda_log_group = runner_binary.lambda_log_group
     lambda_role      = runner_binary.lambda_role
     location         = "s3://runner_binary.bucket.id}/runner_binary.bucket.key"
     bucket           = runner_binary.bucket
-  }]
+  } }
 }
 
 output "webhook" {

--- a/modules/multi-runner/outputs.tf
+++ b/modules/multi-runner/outputs.tf
@@ -1,4 +1,5 @@
 output "runners" {
+  deprication_replacement = "runners_map"
   value = [for runner in module.runners : {
     launch_template_name    = runner.launch_template.name
     launch_template_id      = runner.launch_template.id
@@ -41,6 +42,7 @@ output "runners_map" {
 }
 
 output "binaries_syncer" {
+  deprication_replacement = "binaries_syncer_map"
   value = [for runner_binary in module.runner_binaries : {
     lambda           = runner_binary.lambda
     lambda_log_group = runner_binary.lambda_log_group

--- a/modules/multi-runner/outputs.tf
+++ b/modules/multi-runner/outputs.tf
@@ -1,5 +1,5 @@
 output "runners" {
-  deprication_replacement = "runners_map"
+  description = "(Deprecated, no longer used), see runners_map."
   value = [for runner in module.runners : {
     launch_template_name    = runner.launch_template.name
     launch_template_id      = runner.launch_template.id
@@ -42,7 +42,7 @@ output "runners_map" {
 }
 
 output "binaries_syncer" {
-  deprication_replacement = "binaries_syncer_map"
+  description = "(Deprecated, no longer used), see binaries_syncer_map."
   value = [for runner_binary in module.runner_binaries : {
     lambda           = runner_binary.lambda
     lambda_log_group = runner_binary.lambda_log_group


### PR DESCRIPTION
# Intent
It will be ideal to refer to the outputs of the multi runner module with the corresponding runner configuration key instead of array indices as it can be used to create more resources based on the use case of the runners.

# Impact (Migration)
As of now, there is no impact on migration to this version but we have marked the `multi-runner` outputs `runners` and `binaries_syncer` as deprecated and these shall be removed in next major upgrade.
