### PR TITLE
feat(images): Allow specifying temporary security group source IP for packer builds

### DIFF
--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -78,7 +78,7 @@ variable "custom_shell_commands" {
 }
 
 variable "temporary_security_group_source_public_ip" {
-  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group. Note: If you specify `security_group_id` then this input is ignored."
   type        = bool
   default     = false
 }

--- a/images/linux-amzn2/github_agent.linux.pkr.hcl
+++ b/images/linux-amzn2/github_agent.linux.pkr.hcl
@@ -77,6 +77,12 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+variable "temporary_security_group_source_public_ip" {
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  type        = bool
+  default     = false
+}
+
 data "http" github_runner_release_json {
   url = "https://api.github.com/repos/actions/runner/releases/latest"
   request_headers = {
@@ -90,12 +96,14 @@ locals {
 }
 
 source "amazon-ebs" "githubrunner" {
-  ami_name                    = "github-runner-amzn2-x86_64-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  instance_type               = var.instance_type
-  region                      = var.region
-  security_group_id           = var.security_group_id
-  subnet_id                   = var.subnet_id
-  associate_public_ip_address = var.associate_public_ip_address
+  ami_name                                  = "github-runner-amzn2-x86_64-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  instance_type                             = var.instance_type
+  region                                    = var.region
+  security_group_id                         = var.security_group_id
+  subnet_id                                 = var.subnet_id
+  associate_public_ip_address               = var.associate_public_ip_address
+  temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
+
   source_ami_filter {
     filters = {
       name                = "amzn2-ami-kernel-5.*-hvm-*-x86_64-gp2"

--- a/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
@@ -77,6 +77,12 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+variable "temporary_security_group_source_public_ip" {
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  type        = bool
+  default     = false
+}
+
 data "http" github_runner_release_json {
   url = "https://api.github.com/repos/actions/runner/releases/latest"
   request_headers = {
@@ -90,12 +96,13 @@ locals {
 }
 
 source "amazon-ebs" "githubrunner" {
-  ami_name                    = "github-runner-ubuntu-focal-amd64-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  instance_type               = var.instance_type
-  region                      = var.region
-  security_group_id           = var.security_group_id
-  subnet_id                   = var.subnet_id
-  associate_public_ip_address = var.associate_public_ip_address
+  ami_name                                  = "github-runner-ubuntu-focal-amd64-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  instance_type                             = var.instance_type
+  region                                    = var.region
+  security_group_id                         = var.security_group_id
+  subnet_id                                 = var.subnet_id
+  associate_public_ip_address               = var.associate_public_ip_address
+  temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
 
   source_ami_filter {
     filters = {

--- a/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
@@ -78,7 +78,7 @@ variable "custom_shell_commands" {
 }
 
 variable "temporary_security_group_source_public_ip" {
-  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group. Note: If you specify `security_group_id` then this input is ignored."
   type        = bool
   default     = false
 }

--- a/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
@@ -77,6 +77,12 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+variable "temporary_security_group_source_public_ip" {
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  type        = bool
+  default     = false
+}
+
 data "http" github_runner_release_json {
   url = "https://api.github.com/repos/actions/runner/releases/latest"
   request_headers = {
@@ -90,12 +96,13 @@ locals {
 }
 
 source "amazon-ebs" "githubrunner" {
-  ami_name                    = "github-runner-ubuntu-jammy-arm64-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  instance_type               = var.instance_type
-  region                      = var.region
-  security_group_id           = var.security_group_id
-  subnet_id                   = var.subnet_id
-  associate_public_ip_address = var.associate_public_ip_address
+  ami_name                                  = "github-runner-ubuntu-jammy-arm64-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  instance_type                             = var.instance_type
+  region                                    = var.region
+  security_group_id                         = var.security_group_id
+  subnet_id                                 = var.subnet_id
+  associate_public_ip_address               = var.associate_public_ip_address
+  temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
 
   source_ami_filter {
     filters = {

--- a/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
@@ -78,7 +78,7 @@ variable "custom_shell_commands" {
 }
 
 variable "temporary_security_group_source_public_ip" {
-  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group. Note: If you specify `security_group_id` then this input is ignored."
   type        = bool
   default     = false
 }

--- a/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
@@ -78,7 +78,7 @@ variable "custom_shell_commands" {
 }
 
 variable "temporary_security_group_source_public_ip" {
-  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group. Note: If you specify `security_group_id` then this input is ignored."
   type        = bool
   default     = false
 }

--- a/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
@@ -77,6 +77,12 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+variable "temporary_security_group_source_public_ip" {
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  type        = bool
+  default     = false
+}
+
 data "http" github_runner_release_json {
   url = "https://api.github.com/repos/actions/runner/releases/latest"
   request_headers = {
@@ -90,12 +96,13 @@ locals {
 }
 
 source "amazon-ebs" "githubrunner" {
-  ami_name                    = "github-runner-ubuntu-jammy-amd64-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  instance_type               = var.instance_type
-  region                      = var.region
-  security_group_id           = var.security_group_id
-  subnet_id                   = var.subnet_id
-  associate_public_ip_address = var.associate_public_ip_address
+  ami_name                                  = "github-runner-ubuntu-jammy-amd64-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  instance_type                             = var.instance_type
+  region                                    = var.region
+  security_group_id                         = var.security_group_id
+  subnet_id                                 = var.subnet_id
+  associate_public_ip_address               = var.associate_public_ip_address
+  temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
 
   source_ami_filter {
     filters = {

--- a/images/windows-core-2019/github_agent.windows.pkr.hcl
+++ b/images/windows-core-2019/github_agent.windows.pkr.hcl
@@ -43,7 +43,7 @@ variable "custom_shell_commands" {
 }
 
 variable "temporary_security_group_source_public_ip" {
-  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group. Note: If you specify `security_group_id` then this input is ignored."
   type        = bool
   default     = false
 }

--- a/images/windows-core-2019/github_agent.windows.pkr.hcl
+++ b/images/windows-core-2019/github_agent.windows.pkr.hcl
@@ -42,6 +42,12 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+variable "temporary_security_group_source_public_ip" {
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  type        = bool
+  default     = false
+}
+
 data "http" github_runner_release_json {
   url = "https://api.github.com/repos/actions/runner/releases/latest"
   request_headers = {
@@ -55,11 +61,12 @@ locals {
 }
 
 source "amazon-ebs" "githubrunner" {
-  ami_name                    = "github-runner-windows-core-2019-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  communicator                = "winrm"
-  instance_type               = var.instance_type
-  region                      = var.region
-  associate_public_ip_address = var.associate_public_ip_address
+  ami_name                                  = "github-runner-windows-core-2019-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  communicator                              = "winrm"
+  instance_type                             = var.instance_type
+  region                                    = var.region
+  associate_public_ip_address               = var.associate_public_ip_address
+  temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
 
   source_ami_filter {
     filters = {

--- a/images/windows-core-2022/github_agent.windows.pkr.hcl
+++ b/images/windows-core-2022/github_agent.windows.pkr.hcl
@@ -54,7 +54,7 @@ variable "custom_shell_commands" {
 }
 
 variable "temporary_security_group_source_public_ip" {
-  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group. Note: If you specify `security_group_id` then this input is ignored."
   type        = bool
   default     = false
 }

--- a/images/windows-core-2022/github_agent.windows.pkr.hcl
+++ b/images/windows-core-2022/github_agent.windows.pkr.hcl
@@ -53,6 +53,12 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+variable "temporary_security_group_source_public_ip" {
+  description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group."
+  type        = bool
+  default     = false
+}
+
 data "http" github_runner_release_json {
   url = "https://api.github.com/repos/actions/runner/releases/latest"
   request_headers = {
@@ -66,13 +72,14 @@ locals {
 }
 
 source "amazon-ebs" "githubrunner" {
-  ami_name                    = "github-runner-windows-core-2022-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  communicator                = "winrm"
-  instance_type               = "m4.xlarge"
-  region                      = var.region
-  security_group_id           = var.security_group_id
-  subnet_id                   = var.subnet_id
-  associate_public_ip_address = var.associate_public_ip_address
+  ami_name                                  = "github-runner-windows-core-2022-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  communicator                              = "winrm"
+  instance_type                             = "m4.xlarge"
+  region                                    = var.region
+  security_group_id                         = var.security_group_id
+  subnet_id                                 = var.subnet_id
+  associate_public_ip_address               = var.associate_public_ip_address
+  temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
 
   source_ami_filter {
     filters = {


### PR DESCRIPTION
Currently when packer runs an image build the security group attached to the ec2 instance has an ingress rule that allows access on port 22 from 0.0.0.0/0. In our enterprise environment this is immediately flagged in Security Hub as a critical security finding.

This change will allow packer to restrict the ingress rules of the security group it creates to the IP of the machine running packer (in our case the IP of the Github runner doing our AMI builds).

