### PR TITLE
fix(multi-runner): Fix runner_additional_security_group_ids

### DIFF
--- a/modules/multi-runner/runners.tf
+++ b/modules/multi-runner/runners.tf
@@ -49,7 +49,7 @@ module "runners" {
   idle_config                          = each.value.runner_config.idle_config
   enable_ssm_on_runners                = each.value.runner_config.enable_ssm_on_runners
   egress_rules                         = var.runner_egress_rules
-  runner_additional_security_group_ids = coalesce(each.value.runner_config.runner_additional_security_group_ids, var.runner_additional_security_group_ids)
+  runner_additional_security_group_ids = try(coalescelist(each.value.runner_config.runner_additional_security_group_ids, var.runner_additional_security_group_ids), [])
   metadata_options                     = each.value.runner_config.runner_metadata_options
   credit_specification                 = each.value.runner_config.credit_specification
 


### PR DESCRIPTION
If `runner_additional_security_group_ids` is only set outside the multi_runner_config `coalesce(each.value.runner_config.runner_additional_security_group_ids, var.runner_additional_security_group_ids)` is coalescing an empty list (the default value for `each.value.runner_config.runner_additional_security_group_ids`) with whatever is set outside the multi_runner_config, this always results in the returned value being an empty list:

```
> coalesce([], ["sg-123456"])
tolist([])
```

Using coalescelist instead returns the first non-empty list:

```
> coalescelist([], ["sg-123456"])
[
  "sg-123456",
]
```

And the `try` returns an empty list if both coalesced lists are empty (rather than throwing an error):

```
> try(coalescelist([], []), [])
[]
```