### PR TITLE
feat: tag runner volumes with the same tags as the instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ secrets.auto.tfvars
 
 node_modules/
 
-.terraform.lock.hcl

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ secrets.auto.tfvars
 **/coverage/*
 
 node_modules/
+
+.terraform.lock.hcl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,16 @@ Before you submit your pull request consider the following guidelines:
 
 * Create your patch, **including appropriate test cases**.
 * Install [Terraform](https://www.terraform.io/). We lock the version with [tfenv](https://github.com/tfutils/tfenv), check `required_version` in `versions.tf` for the current development version of the module.
-* Install [pre-commit hooks](https://pre-commit.com/). The hooks runs some basic checks. The commit will run the hooks, you can invoke the hooks manually `pre-commit run --all-files` as well.
+* Install [pre-commit hooks](https://pre-commit.com/). The hooks runs some basic checks. The commit will run the hooks, you can invoke the hooks manually `pre-commit run --all-files` as well. The hooks require tflint to be installed and terraform modules to be initialized.
+    * Install [tflint](https://github.com/terraform-linters/tflint). We use tflint to lint the terraform code.
+    * Initialize the terraform modules:
+
+        ```shell
+        terraform init
+        ```
+
 * For updating docs, you have to enable GitHub actions on your forked repository. Simply go to the tab Actions and enable actions.
-* Commit your changes using a descriptive commit message.
+* Commit your changes using a descriptive commit message:
 
     ```shell
     git commit -a
@@ -73,7 +80,19 @@ Before you submit your pull request consider the following guidelines:
 
   Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
 
+* Install [node](https://nodejs.org/en/) and [yarn](https://yarnpkg.com/). We use yarn to lint, test and build the lambdas.
 * Build your changes locally to ensure all the tests pass:
+
+        ```shell
+        cd lambdas
+        yarn install
+        yarn format
+        yarn lint
+        yarn test
+        yarn build
+        cd ..
+        ```
+
 * Push your branch to Github:
 
     ```shell

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -157,6 +157,12 @@ export async function createRunner(runnerParameters: Runners.RunnerInputParamete
   }
 
   const numberOfRunners = runnerParameters.numberOfRunners ? runnerParameters.numberOfRunners : 1;
+  const tags = [
+    { Key: 'ghr:Application', Value: 'github-action-runner' },
+    { Key: 'ghr:created_by', Value: numberOfRunners === 1 ? 'scale-up-lambda' : 'pool-lambda' },
+    { Key: 'Type', Value: runnerParameters.runnerType },
+    { Key: 'Owner', Value: runnerParameters.runnerOwner },
+  ];
 
   let fleet: CreateFleetResult;
   try {
@@ -186,12 +192,11 @@ export async function createRunner(runnerParameters: Runners.RunnerInputParamete
       TagSpecifications: [
         {
           ResourceType: 'instance',
-          Tags: [
-            { Key: 'ghr:Application', Value: 'github-action-runner' },
-            { Key: 'ghr:created_by', Value: numberOfRunners === 1 ? 'scale-up-lambda' : 'pool-lambda' },
-            { Key: 'Type', Value: runnerParameters.runnerType },
-            { Key: 'Owner', Value: runnerParameters.runnerOwner },
-          ],
+          Tags: tags,
+        },
+        {
+          ResourceType: 'volume',
+          Tags: tags,
         },
       ],
       Type: 'instant',


### PR DESCRIPTION
#### Description

Currently, volumes attached to runners are only tagged with tags specified by the AWS Launch Template. In particular, they're missing `Owner` tag, which can only be applied during "runtime".

This PR changes the way instances are created from the launch template. It adds tag specifications for the `volume` resource type to the instance creation request. With that input, the created volumes will have the same tags as the instance itself.

During the creation of this PR I noticed I had to perform a few more actions to be able to test it. I added the new instructions to the contribution guide.

I also added terraform lock file to git ignore because `terraform init` creates it and I didn't see it being committed before.

#### Testing

- [x] Ran `yarn test` in `lambdas` directory