### PR TITLE
chore: group dependencies of aws-sdk and octokit.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,13 @@ updates:
     directory: "/lambdas"
     schedule:
       interval: "weekly"
+    group:
+      aws:
+        patterns:
+          - "@aws-sdk/*"
+      octokit:
+        patterns:
+          - "@octokit/*"
     commit-message:
       prefix: "fix(lambda)"
       prefix-development: "chore(lambda)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     directory: "/lambdas"
     schedule:
       interval: "weekly"
-    group:
+    groups:
       aws:
         patterns:
           - "@aws-sdk/*"


### PR DESCRIPTION
Based on new functionality

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups