### PR TITLE
fix: broken AMI fileter

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -38,7 +38,7 @@ locals {
   }
 
   ami_kms_key_arn = var.ami_kms_key_arn != null ? var.ami_kms_key_arn : ""
-  ami_filter      = coalesce(var.ami_filter, local.default_ami[var.runner_os])
+  ami_filter      = merge(local.default_ami[var.runner_os], var.ami_filter)
 
   enable_job_queued_check = var.enable_job_queued_check == null ? !var.enable_ephemeral_runners : var.enable_job_queued_check
 }


### PR DESCRIPTION
After introducing the default value of `{state = ["Available"]}`, we missed to update the logic around the use of default filters and the custom filters.
With this change:

 - If `ami_filter` is NOT changed by the root module user, it will be merged with default value of `local.default_ami` and the output will have combination of default_ami and `{state = ["Available"]}`.
 - If `ami_filter` is CHANGED by the root module user with a new value of `name`, the default value will be overriden as a result of the merge operation.
 - if `ami_filter` is explicitly set to null, variable validation will fail and not proceed.

