### PR TITLE
fix(runners): ensure `/opt/start-runner-service.sh` is run with Bash

### DIFF
--- a/modules/runners/templates/start-runner.sh
+++ b/modules/runners/templates/start-runner.sh
@@ -135,9 +135,8 @@ cat >/opt/start-runner-service.sh <<-EOF
   echo "Terminating instance"
   aws ec2 terminate-instances --instance-ids "$instance_id" --region "$region"
 EOF
-  chmod 755 /opt/start-runner-service.sh
   # Starting the runner via a own process to ensure this process terminates
-  nohup /opt/start-runner-service.sh &
+  nohup bash /opt/start-runner-service.sh &
 
 else
   echo "Installing the runner as a service"


### PR DESCRIPTION
#3393 broke (Ubuntu) ephemeral runners when `enable_jit_config = true`.

The introduction of `enable_jit_config` came with an update of script `/opt/start-runner-service.sh` that required it to run in a shell with *double bracket* keyword support:

https://github.com/philips-labs/terraform-aws-github-runner/blob/cfbcc944fc183b481caaee323e7832ec1964eb54/modules/runners/templates/start-runner.sh#L123-L129

Currently, script `/opt/start-runner-service.sh` is chmoded executable but has no shebang.
In Ubuntu, this results in `nohup` running it with plain `sh`, hence the following error log:

```log
Starting the runner as user ubuntu
Starting the runner in ephemeral mode
/opt/start-runner-service.sh: 4: [[: not found
Starting without JIT config
An error occurred: Not configured. Run config.(sh/cmd) to configure the runner.
Runner listener exit with terminated error, stop the service, no retry needed.
Exiting runner...
Runner has finished
Stopping cloudwatch service
Terminating instance
```

These changes ensure that `nohup` runs the script with `bash`.