### PR TITLE
fix: set log retention in each module by default to 180

### DIFF
--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -224,7 +224,7 @@ variable "role_path" {
 variable "logging_retention_in_days" {
   description = "Specifies the number of days you want to retain log events for the lambda log group. Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653."
   type        = number
-  default     = 7
+  default     = 180
 }
 
 variable "logging_kms_key_id" {

--- a/modules/runner-binaries-syncer/variables.tf
+++ b/modules/runner-binaries-syncer/variables.tf
@@ -119,7 +119,7 @@ variable "runner_architecture" {
 variable "logging_retention_in_days" {
   description = "Specifies the number of days you want to retain log events for the lambda log group. Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653."
   type        = number
-  default     = 7
+  default     = 180
 }
 
 variable "logging_kms_key_id" {

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -80,7 +80,7 @@ variable "role_path" {
 variable "logging_retention_in_days" {
   description = "Specifies the number of days you want to retain log events for the lambda log group. Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653."
   type        = number
-  default     = 7
+  default     = 180
 }
 
 variable "logging_kms_key_id" {


### PR DESCRIPTION
Top level module has set log retention to 180 days. This PR's ensure that each module is applying the same default.