### PR TITLE
fix: Replace defaul AMI for WIndows

### DIFF
--- a/examples/multi-runner/templates/runner-configs/windows-x64.yaml
+++ b/examples/multi-runner/templates/runner-configs/windows-x64.yaml
@@ -18,6 +18,6 @@ runner_config:
   runner_boot_time_in_minutes: 20
   ami_filter:
     name:
-      - Windows_Server-2022-English-Core-ContainersLatest-*
+      - Windows_Server-2022-English-Full-ECS_Optimized-*
     state:
       - available

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -18,7 +18,7 @@ locals {
   kms_key_arn                     = var.kms_key_arn != null ? var.kms_key_arn : ""
   s3_location_runner_distribution = var.enable_runner_binaries_syncer ? "s3://${var.s3_runner_binaries.id}/${var.s3_runner_binaries.key}" : ""
   default_ami = {
-    "windows" = { name = ["Windows_Server-2022-English-Core-ContainersLatest-*"] }
+    "windows" = { name = ["Windows_Server-2022-English-Full-ECS_Optimized-*"] }
     "linux"   = var.runner_architecture == "arm64" ? { name = ["amzn2-ami-kernel-5.*-hvm-*-arm64-gp2"] } : { name = ["amzn2-ami-kernel-5.*-hvm-*-x86_64-gp2"] }
   }
 


### PR DESCRIPTION
Replace Window AMI by  Windows_Server-2022-English-Full-ECS_Optimized-*

close #3423 