### PR TITLE
feat: support for cloudwatch config on multi-runners

### DIFF
--- a/modules/multi-runner/runners.tf
+++ b/modules/multi-runner/runners.tf
@@ -69,7 +69,7 @@ module "runners" {
   logging_retention_in_days        = var.logging_retention_in_days
   logging_kms_key_id               = var.logging_kms_key_id
   enable_cloudwatch_agent          = each.value.runner_config.enable_cloudwatch_agent
-  cloudwatch_config                = each.value.runner_config.cloudwatch_config
+  cloudwatch_config                = coalesce(each.value.runner_config.cloudwatch_config, var.cloudwatch_config)
   runner_log_files                 = each.value.runner_config.runner_log_files
   runner_group_name                = each.value.runner_config.runner_group_name
   runner_name_prefix               = each.value.runner_config.runner_name_prefix

--- a/modules/multi-runner/runners.tf
+++ b/modules/multi-runner/runners.tf
@@ -69,7 +69,7 @@ module "runners" {
   logging_retention_in_days        = var.logging_retention_in_days
   logging_kms_key_id               = var.logging_kms_key_id
   enable_cloudwatch_agent          = each.value.runner_config.enable_cloudwatch_agent
-  cloudwatch_config                = coalesce(each.value.runner_config.cloudwatch_config, var.cloudwatch_config)
+  cloudwatch_config                = try(coalesce(each.value.runner_config.cloudwatch_config, var.cloudwatch_config), null)
   runner_log_files                 = each.value.runner_config.runner_log_files
   runner_group_name                = each.value.runner_config.runner_group_name
   runner_name_prefix               = each.value.runner_config.runner_name_prefix

--- a/modules/multi-runner/runners.tf
+++ b/modules/multi-runner/runners.tf
@@ -69,7 +69,7 @@ module "runners" {
   logging_retention_in_days        = var.logging_retention_in_days
   logging_kms_key_id               = var.logging_kms_key_id
   enable_cloudwatch_agent          = each.value.runner_config.enable_cloudwatch_agent
-  cloudwatch_config                = var.cloudwatch_config
+  cloudwatch_config                = each.value.runner_config.cloudwatch_config
   runner_log_files                 = each.value.runner_config.runner_log_files
   runner_group_name                = each.value.runner_config.runner_group_name
   runner_name_prefix               = each.value.runner_config.runner_name_prefix

--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -168,7 +168,6 @@ variable "multi_runner_config" {
         enable_runner_detailed_monitoring: "Should detailed monitoring be enabled for the runner. Set this to true if you want to use detailed monitoring. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html for details."
         enable_cloudwatch_agent: "Enabling the cloudwatch agent on the ec2 runner instances, the runner contains default config. Configuration can be overridden via `cloudwatch_config`."
         cloudwatch_config: "(optional) Replaces the module default cloudwatch log config. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html for details."
-"
         userdata_pre_install: "Script to be ran before the GitHub Actions runner is installed on the EC2 instances"
         userdata_post_install: "Script to be ran after the GitHub Actions runner is installed on the EC2 instances"
         runner_ec2_tags: "Map of tags that will be added to the launch template instance tag specifications."

--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -167,6 +167,8 @@ variable "multi_runner_config" {
         enable_jit_config "Overwrite the default behavior for JIT configuration. By default JIT configuration is enabled for ephemeral runners and disabled for non-ephemeral runners. In case of GHES check first if the JIT config API is avaialbe. In case you upgradeing from 3.x to 4.x you can set `enable_jit_config` to `false` to avoid a breaking change when having your own AMI."
         enable_runner_detailed_monitoring: "Should detailed monitoring be enabled for the runner. Set this to true if you want to use detailed monitoring. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html for details."
         enable_cloudwatch_agent: "Enabling the cloudwatch agent on the ec2 runner instances, the runner contains default config. Configuration can be overridden via `cloudwatch_config`."
+        cloudwatch_config: "(optional) Replaces the module default cloudwatch log config. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html for details."
+"
         userdata_pre_install: "Script to be ran before the GitHub Actions runner is installed on the EC2 instances"
         userdata_post_install: "Script to be ran after the GitHub Actions runner is installed on the EC2 instances"
         runner_ec2_tags: "Map of tags that will be added to the launch template instance tag specifications."

--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -71,6 +71,7 @@ variable "multi_runner_config" {
       enable_jit_config                       = optional(bool, null)
       enable_runner_detailed_monitoring       = optional(bool, false)
       enable_cloudwatch_agent                 = optional(bool, true)
+      cloudwatch_config                       = optional(string, null)
       userdata_pre_install                    = optional(string, "")
       userdata_post_install                   = optional(string, "")
       runner_ec2_tags                         = optional(map(string), {})


### PR DESCRIPTION
## Problem
Cloud config can only set for all multi-runners and not per runner. 

## Solution
Add option to set the cloud config per runner.