### PR TITLE
feat(webhook): add support of disabling api gateway execute endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ We welcome any improvement to the standard module to make the default as secure 
 | <a name="input_webhook_lambda_s3_object_version"></a> [webhook\_lambda\_s3\_object\_version](#input\_webhook\_lambda\_s3\_object\_version) | S3 object version for webhook lambda function. Useful if S3 versioning is enabled on source bucket. | `string` | `null` | no |
 | <a name="input_webhook_lambda_timeout"></a> [webhook\_lambda\_timeout](#input\_webhook\_lambda\_timeout) | Time out of the webhook lambda in seconds. | `number` | `10` | no |
 | <a name="input_webhook_lambda_zip"></a> [webhook\_lambda\_zip](#input\_webhook\_lambda\_zip) | File location of the webhook lambda zip file. | `string` | `null` | no |
+| <a name="input_webhook_apigateway_disable_execute_api_endpoint"></a> [webhook\_apigateway\_disable\_execute\_api\_endpoint](#input\_webhook\_apigateway\_disable\_execute\_api\_endpoint) | Disable execute API Gateway endpoint in case custom domain is used. | `bool` | `false` | no |
 | <a name="input_workflow_job_queue_configuration"></a> [workflow\_job\_queue\_configuration](#input\_workflow\_job\_queue\_configuration) | Configuration options for workflow job queue which is only applicable if the flag enable\_workflow\_job\_events\_queue is set to true. | <pre>object({<br>    delay_seconds              = number<br>    visibility_timeout_seconds = number<br>    message_retention_seconds  = number<br>  })</pre> | <pre>{<br>  "delay_seconds": null,<br>  "message_retention_seconds": null,<br>  "visibility_timeout_seconds": null<br>}</pre> | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -146,17 +146,18 @@ module "webhook" {
     webhook_secret = module.ssm.parameters.github_app_webhook_secret
   }
 
-  lambda_s3_bucket                              = var.lambda_s3_bucket
-  webhook_lambda_s3_key                         = var.webhook_lambda_s3_key
-  webhook_lambda_s3_object_version              = var.webhook_lambda_s3_object_version
-  webhook_lambda_apigateway_access_log_settings = var.webhook_lambda_apigateway_access_log_settings
-  lambda_runtime                                = var.lambda_runtime
-  lambda_architecture                           = var.lambda_architecture
-  lambda_zip                                    = var.webhook_lambda_zip
-  lambda_timeout                                = var.webhook_lambda_timeout
-  lambda_tracing_mode                           = var.lambda_tracing_mode
-  logging_retention_in_days                     = var.logging_retention_in_days
-  logging_kms_key_id                            = var.logging_kms_key_id
+  lambda_s3_bucket                                = var.lambda_s3_bucket
+  webhook_lambda_s3_key                           = var.webhook_lambda_s3_key
+  webhook_lambda_s3_object_version                = var.webhook_lambda_s3_object_version
+  webhook_lambda_apigateway_access_log_settings   = var.webhook_lambda_apigateway_access_log_settings
+  webhook_apigateway_disable_execute_api_endpoint = var.webhook_apigateway_disable_execute_api_endpoint
+  lambda_runtime                                  = var.lambda_runtime
+  lambda_architecture                             = var.lambda_architecture
+  lambda_zip                                      = var.webhook_lambda_zip
+  lambda_timeout                                  = var.webhook_lambda_timeout
+  lambda_tracing_mode                             = var.lambda_tracing_mode
+  logging_retention_in_days                       = var.logging_retention_in_days
+  logging_kms_key_id                              = var.logging_kms_key_id
 
   role_path                 = var.role_path
   role_permissions_boundary = var.role_permissions_boundary

--- a/modules/multi-runner/README.md
+++ b/modules/multi-runner/README.md
@@ -169,6 +169,7 @@ module "multi-runner" {
 | <a name="input_webhook_lambda_s3_object_version"></a> [webhook\_lambda\_s3\_object\_version](#input\_webhook\_lambda\_s3\_object\_version) | S3 object version for webhook lambda function. Useful if S3 versioning is enabled on source bucket. | `string` | `null` | no |
 | <a name="input_webhook_lambda_timeout"></a> [webhook\_lambda\_timeout](#input\_webhook\_lambda\_timeout) | Time out of the lambda in seconds. | `number` | `10` | no |
 | <a name="input_webhook_lambda_zip"></a> [webhook\_lambda\_zip](#input\_webhook\_lambda\_zip) | File location of the webhook lambda zip file. | `string` | `null` | no |
+| <a name="input_webhook_apigateway_disable_execute_api_endpoint"></a> [webhook\_apigateway\_disable\_execute\_api\_endpoint](#input\_webhook\_apigateway\_disable\_execute\_api\_endpoint) | Disable execute API Gateway endpoint in case custom domain is used. | `bool` | `false` | no |
 | <a name="input_workflow_job_queue_configuration"></a> [workflow\_job\_queue\_configuration](#input\_workflow\_job\_queue\_configuration) | Configuration options for workflow job queue which is only applicable if the flag enable\_workflow\_job\_events\_queue is set to true. | <pre>object({<br>    delay_seconds              = number<br>    visibility_timeout_seconds = number<br>    message_retention_seconds  = number<br>  })</pre> | <pre>{<br>  "delay_seconds": null,<br>  "message_retention_seconds": null,<br>  "visibility_timeout_seconds": null<br>}</pre> | no |
 
 ## Outputs

--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -262,6 +262,12 @@ variable "webhook_lambda_apigateway_access_log_settings" {
   default = null
 }
 
+variable "webhook_apigateway_disable_execute_api_endpoint" {
+  description = "Disable execute API Gateway endpoint in case custom domain is used."
+  type        = bool
+  default     = false
+}
+
 variable "repository_white_list" {
   description = "List of github repository full names (owner/repo_name) that will be allowed to use the github app. Leave empty for no filtering."
   type        = list(string)

--- a/modules/multi-runner/webhook.tf
+++ b/modules/multi-runner/webhook.tf
@@ -11,17 +11,18 @@ module "webhook" {
     webhook_secret = module.ssm.parameters.github_app_webhook_secret
   }
 
-  lambda_s3_bucket                              = var.lambda_s3_bucket
-  webhook_lambda_s3_key                         = var.webhook_lambda_s3_key
-  webhook_lambda_s3_object_version              = var.webhook_lambda_s3_object_version
-  webhook_lambda_apigateway_access_log_settings = var.webhook_lambda_apigateway_access_log_settings
-  lambda_runtime                                = var.lambda_runtime
-  lambda_architecture                           = var.lambda_architecture
-  lambda_zip                                    = var.webhook_lambda_zip
-  lambda_timeout                                = var.webhook_lambda_timeout
-  lambda_tracing_mode                           = var.lambda_tracing_mode
-  logging_retention_in_days                     = var.logging_retention_in_days
-  logging_kms_key_id                            = var.logging_kms_key_id
+  lambda_s3_bucket                                = var.lambda_s3_bucket
+  webhook_lambda_s3_key                           = var.webhook_lambda_s3_key
+  webhook_lambda_s3_object_version                = var.webhook_lambda_s3_object_version
+  webhook_lambda_apigateway_access_log_settings   = var.webhook_lambda_apigateway_access_log_settings
+  webhook_apigateway_disable_execute_api_endpoint = var.webhook_apigateway_disable_execute_api_endpoint
+  lambda_runtime                                  = var.lambda_runtime
+  lambda_architecture                             = var.lambda_architecture
+  lambda_zip                                      = var.webhook_lambda_zip
+  lambda_timeout                                  = var.webhook_lambda_timeout
+  lambda_tracing_mode                             = var.lambda_tracing_mode
+  logging_retention_in_days                       = var.logging_retention_in_days
+  logging_kms_key_id                              = var.logging_kms_key_id
 
   role_path                 = var.role_path
   role_permissions_boundary = var.role_permissions_boundary

--- a/modules/webhook/README.md
+++ b/modules/webhook/README.md
@@ -104,6 +104,7 @@ No modules.
 | <a name="input_webhook_lambda_apigateway_access_log_settings"></a> [webhook\_lambda\_apigateway\_access\_log\_settings](#input\_webhook\_lambda\_apigateway\_access\_log\_settings) | Access log settings for webhook API gateway. | <pre>object({<br>    destination_arn = string<br>    format          = string<br>  })</pre> | `null` | no |
 | <a name="input_webhook_lambda_s3_key"></a> [webhook\_lambda\_s3\_key](#input\_webhook\_lambda\_s3\_key) | S3 key for webhook lambda function. Required if using S3 bucket to specify lambdas. | `string` | `null` | no |
 | <a name="input_webhook_lambda_s3_object_version"></a> [webhook\_lambda\_s3\_object\_version](#input\_webhook\_lambda\_s3\_object\_version) | S3 object version for webhook lambda function. Useful if S3 versioning is enabled on source bucket. | `string` | `null` | no |
+| <a name="input_webhook_apigateway_disable_execute_api_endpoint"></a> [webhook\_apigateway\_disable\_execute\_api\_endpoint](#input\_webhook\_apigateway\_disable\_execute\_api\_endpoint) | Disable execute API Gateway endpoint in case custom domain is used. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/webhook/main.tf
+++ b/modules/webhook/main.tf
@@ -5,9 +5,10 @@ locals {
 }
 
 resource "aws_apigatewayv2_api" "webhook" {
-  name          = "${var.prefix}-github-action-webhook"
-  protocol_type = "HTTP"
-  tags          = var.tags
+  name                         = "${var.prefix}-github-action-webhook"
+  protocol_type                = "HTTP"
+  disable_execute_api_endpoint = var.webhook_apigateway_disable_execute_api_endpoint
+  tags                         = var.tags
 }
 
 resource "aws_apigatewayv2_route" "webhook" {

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -116,6 +116,12 @@ variable "webhook_lambda_apigateway_access_log_settings" {
   default = null
 }
 
+variable "webhook_apigateway_disable_execute_api_endpoint" {
+  description = "Disable execute API Gateway endpoint in case custom domain is used."
+  type        = bool
+  default     = false
+}
+
 variable "repository_white_list" {
   description = "List of github repository full names (owner/repo_name) that will be allowed to use the github app. Leave empty for no filtering."
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -369,6 +369,12 @@ variable "webhook_lambda_apigateway_access_log_settings" {
   default = null
 }
 
+variable "webhook_apigateway_disable_execute_api_endpoint" {
+  description = "Disable execute API Gateway endpoint in case custom domain is used."
+  type        = bool
+  default     = false
+}
+
 variable "runners_lambda_s3_key" {
   description = "S3 key for runners lambda function. Required if using S3 bucket to specify lambdas."
   type        = string


### PR DESCRIPTION
First of all I'd like to thank you for providing this awesome Terraform module. I really appreciate the work you put into this!

Currently we're using GitHub Enterprise and our company policies deny sending webhooks to domains which do not refer to company managed domains (ike the AWS provided domain for the API Gateway). Therefore, we added a custom domain to our api gateway. In order to use custom domains for the API Gateway we need to disable the default execute api endpoint, otherwise custom domains are not going to work.

At the moment Terraform detect the manually applied changes on the API Gateway in regards to disabling the execute endpoint. Hence, at each run Terraform would like to apply the old configuration. This PR adds the possibility to disable the execute endpoint.

If you have any questions to this, I'd be happy to answer it.