### PR TITLE
feat: Add ebs_optimized option

### DIFF
--- a/modules/multi-runner/runners.tf
+++ b/modules/multi-runner/runners.tf
@@ -33,6 +33,7 @@ module "runners" {
 
   sqs_build_queue                      = { "arn" : each.value.arn }
   github_app_parameters                = local.github_app_parameters
+  ebs_optimized                        = each.value.runner_config.ebs_optimized
   enable_organization_runners          = each.value.runner_config.enable_organization_runners
   enable_ephemeral_runners             = each.value.runner_config.enable_ephemeral_runners
   enable_jit_config                    = each.value.runner_config.enable_jit_config

--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -44,6 +44,7 @@ variable "multi_runner_config" {
       credit_specification                    = optional(string, null)
       delay_webhook_event                     = optional(number, 30)
       disable_runner_autoupdate               = optional(bool, false)
+      ebs_optimized                           = optional(bool, false)
       enable_ephemeral_runners                = optional(bool, false)
       enable_job_queued_check                 = optional(bool, null)
       enable_organization_runners             = optional(bool, false)
@@ -140,6 +141,7 @@ variable "multi_runner_config" {
         credit_specification: "(Optional) The credit specification of the runner instance_type. Can be unset, `standard` or `unlimited`.
         delay_webhook_event: "The number of seconds the event accepted by the webhook is invisible on the queue before the scale up lambda will receive the event."
         disable_runner_autoupdate: "Disable the auto update of the github runner agent. Be aware there is a grace period of 30 days, see also the [GitHub article](https://github.blog/changelog/2022-02-01-github-actions-self-hosted-runners-can-now-disable-automatic-updates/)"
+        ebs_optimized: "The EC2 EBS optimized configuration."
         enable_ephemeral_runners: "Enable ephemeral runners, runners will only be used once."
         enable_job_queued_check: "Enables JIT configuration for creating runners instead of registration token based registraton. JIT configuration will only be applied for ephemeral runners. By default JIT confiugration is enabled for ephemeral runners an can be disabled via this override. When running on GHES without support for JIT configuration this variable should be set to true for ephemeral runners."
         enable_organization_runners: "Register runners to organization, instead of repo level"

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -117,6 +117,7 @@ resource "aws_launch_template" "runner" {
   instance_initiated_shutdown_behavior = "terminate"
   image_id                             = data.aws_ami.runner.id
   key_name                             = var.key_name
+  ebs_optimized                        = var.ebs_optimized
 
   vpc_security_group_ids = compact(concat(
     var.enable_managed_runner_security_group ? [aws_security_group.runner_sg[0].id] : [],

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -73,6 +73,12 @@ variable "block_device_mappings" {
   }]
 }
 
+variable "ebs_optimized" {
+  description = "The EC2 EBS optimized configuration."
+  type = bool
+  default = false
+}
+
 variable "instance_target_capacity_type" {
   description = "Default lifecyle used runner instances, can be either `spot` or `on-demand`."
   type        = string

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -75,8 +75,8 @@ variable "block_device_mappings" {
 
 variable "ebs_optimized" {
   description = "The EC2 EBS optimized configuration."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "instance_target_capacity_type" {


### PR DESCRIPTION
Fixes: https://github.com/philips-labs/terraform-aws-github-runner/issues/2988

Adds ebs_optimized parameter for ec2 instances.

Currently this defaults to false to keep it in line with the previous behavior.