### PR TITLE
fix: missing partion in ARN to support China or govCloud

### DIFF
--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -99,7 +99,7 @@ resource "aws_iam_role_policy" "scale_up" {
     sqs_arn                   = var.sqs_build_queue.arn
     github_app_id_arn         = var.github_app_parameters.id.arn
     github_app_key_base64_arn = var.github_app_parameters.key_base64.arn
-    ssm_config_path           = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${var.ssm_paths.root}/${var.ssm_paths.config}"
+    ssm_config_path           = "arn:${var.aws_partition}:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter${var.ssm_paths.root}/${var.ssm_paths.config}"
     kms_key_arn               = local.kms_key_arn
     ami_kms_key_arn           = local.ami_kms_key_arn
   })


### PR DESCRIPTION
Fixed the problem of AWS not being able to run correctly in China due to partition errors