### PR TITLE
feat: Set up per runner type subnet specification for multi-runner

### DIFF
--- a/modules/multi-runner/runners.tf
+++ b/modules/multi-runner/runners.tf
@@ -4,14 +4,13 @@ module "runners" {
   aws_region    = var.aws_region
   aws_partition = var.aws_partition
   vpc_id        = var.vpc_id
-  subnet_ids    = var.subnet_ids
   prefix        = "${var.prefix}-${each.key}"
   tags = merge(local.tags, {
     "ghr:environment" = "${var.prefix}-${each.key}"
   })
 
   s3_runner_binaries = each.value.runner_config.enable_runner_binaries_syncer ? local.runner_binaries_by_os_and_arch_map["${each.value.runner_config.runner_os}_${each.value.runner_config.runner_architecture}"] : null
-
+  subnet_ids         = length(each.value.runner_config.subnet_ids) > 0 ? each.value.runner_config.subnet_ids : var.subnet_ids
   ssm_paths = {
     root   = "${local.ssm_root_path}/${each.key}"
     tokens = "${var.ssm_paths.runners}/tokens"

--- a/modules/multi-runner/variables.tf
+++ b/modules/multi-runner/variables.tf
@@ -55,6 +55,7 @@ variable "multi_runner_config" {
       instance_max_spot_price                 = optional(string, null)
       instance_target_capacity_type           = optional(string, "spot")
       instance_types                          = list(string)
+      subnet_ids                              = optional(list(string), [])
       job_queue_retention_in_seconds          = optional(number, 86400)
       minimum_running_time_in_minutes         = optional(number, null)
       pool_runner_owner                       = optional(string, null)


### PR DESCRIPTION
Resolves https://github.com/philips-labs/terraform-aws-github-runner/issues/3515
This just adds the ability to specify a specific subnet_id for a specific runner type for the multi-runner module. There should still always be subnet_ids specified at the module level for the default, but if subnet_ids are specified at the runner level they should override the module level values.

This will enable users to have runners in different subnets without needing to call this module multiple times.