### PR TITLE
fix: Add enable_organization_runners: true to multi example

### DIFF
--- a/examples/multi-runner/templates/runner-configs/linux-x64-ubuntu.yaml
+++ b/examples/multi-runner/templates/runner-configs/linux-x64-ubuntu.yaml
@@ -15,6 +15,7 @@ runner_config:
   runner_run_as: ubuntu
   runner_name_prefix: ubuntu-2204-x64_
   enable_ssm_on_runners: true
+  enable_organization_runners: true
   credit_specification: standard
   instance_types:
     - t3a.large

--- a/examples/multi-runner/templates/runner-configs/linux-x64-ubuntu.yaml
+++ b/examples/multi-runner/templates/runner-configs/linux-x64-ubuntu.yaml
@@ -15,7 +15,7 @@ runner_config:
   runner_run_as: ubuntu
   runner_name_prefix: ubuntu-2204-x64_
   enable_ssm_on_runners: true
-  enable_organization_runners: true
+  enable_organization_runners: true 
   credit_specification: standard
   instance_types:
     - t3a.large


### PR DESCRIPTION
I tried repo level runners and ran into #3527 . This may be indicative of a bug at a different level, but at least this allows a working example.