### PR TITLE
fix(webhook): Avoid jobs are accepted without labels

### DIFF
--- a/lambdas/functions/webhook/jest.config.ts
+++ b/lambdas/functions/webhook/jest.config.ts
@@ -6,10 +6,10 @@ const config: Config = {
   ...defaultConfig,
   coverageThreshold: {
     global: {
-      statements: 99,
-      branches: 86,
+      statements: 99.07,
+      branches: 93.33,
       functions: 100,
-      lines: 99,
+      lines: 99.02,
     },
   },
 };

--- a/lambdas/functions/webhook/src/webhook/handler.ts
+++ b/lambdas/functions/webhook/src/webhook/handler.ts
@@ -158,7 +158,7 @@ function isRepoNotAllowed(repoFullName: string, repositoryWhiteList: string[]): 
   return repositoryWhiteList.length > 0 && !repositoryWhiteList.includes(repoFullName);
 }
 
-function canRunJob(
+export function canRunJob(
   workflowJobLabels: string[],
   runnerLabelsMatchers: string[][],
   workflowLabelCheckAll: boolean,
@@ -166,9 +166,10 @@ function canRunJob(
   runnerLabelsMatchers = runnerLabelsMatchers.map((runnerLabel) => {
     return runnerLabel.map((label) => label.toLowerCase());
   });
-  const match = workflowLabelCheckAll
+  const matchLabels = workflowLabelCheckAll
     ? runnerLabelsMatchers.some((rl) => workflowJobLabels.every((wl) => rl.includes(wl.toLowerCase())))
     : runnerLabelsMatchers.some((rl) => workflowJobLabels.some((wl) => rl.includes(wl.toLowerCase())));
+  const match = workflowJobLabels.length === 0 ? !matchLabels : matchLabels;
 
   logger.debug(
     `Received workflow job event with labels: '${JSON.stringify(workflowJobLabels)}'. The event does ${

--- a/modules/webhook/variables.tf
+++ b/modules/webhook/variables.tf
@@ -34,7 +34,7 @@ variable "tags" {
 }
 
 variable "runner_config" {
-  description = "SQS queue to publish accepted build events based on the runner type."
+  description = "SQS queue to publish accepted build events based on the runner type. When exact match is disabled the webhook accecpts the event if one of the workflow job labels is part of the matcher."
   type = map(object({
     arn  = string
     id   = string


### PR DESCRIPTION
## Descirption

When using the mult-runner with an exact match set to `true` worklfows events with an empty array of labels matches the first matcher. This cause not intented runners are created. This change avoids jobs with no labels ar accepted.

The exactMatch is some bagage we ccarry from the past. I have aaded a set of unit tests to show how the match is working. We should think about removing the switch. 