### PR TITLE
feat: add option to use owner created bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -286,7 +286,8 @@ module "runner_binaries" {
   prefix = var.prefix
   tags   = local.tags
 
-  distribution_bucket_name = lower("${var.prefix}-dist-${random_string.random.result}")
+  use_existing_bucket = var.runner_distribution_bucket_name != null ? true : false
+  distribution_bucket_name = try(var.runner_distribution_bucket_name, lower("${var.prefix}-dist-${random_string.random.result}"))
   s3_logging_bucket        = var.runner_binaries_s3_logging_bucket
   s3_logging_bucket_prefix = var.runner_binaries_s3_logging_bucket_prefix
 

--- a/modules/runner-binaries-syncer/variables.tf
+++ b/modules/runner-binaries-syncer/variables.tf
@@ -32,6 +32,12 @@ variable "distribution_bucket_name" {
   }
 }
 
+variable "use_existing_bucket" {
+  description = "Use an existing bucket for storing the action runner distribution."
+  type        = bool
+  default     = false
+}
+
 variable "s3_logging_bucket" {
   description = "Bucket for action runner distribution bucket access logging."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -800,3 +800,9 @@ variable "enable_jit_config" {
   type        = bool
   default     = null
 }
+
+variable "runner_distribution_bucket_name" {
+  description = "Name of an existing S3 bucket to store the runner binaries. If left empty, a new bucket will be created."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Background:
I have a need to create multiple instances of the main module per team. I cannot use the  multi-runner config because:
1. Lambdas have a limit to the size of their environment variables, so at some point as we add teams and repos, we will hit this 4kb limit. We could group by teams, but...
2. We need to support multiple VPCs, so even if we group by teams, we would further break it down by VPC, which would mean we would have one or two runner configs per "multi-runner" config. The added complexity is not worth the minimal savings in resources.

Allowing for the use of a user defined bucket reduces the number of buckets created. Also, the naming convention I would need to use on a per team basis attempts creates at least 3 buckets with a name that is too long due to the random string added to the bucket created by this module.

## Changes Made
Added `use_existing_bucket` var to `runner-binaries-syncer` module. This is used to allow or prevent the creation of any bucket resources in this file. Logic is also added to use a data source or the auto created bucket depending on the `use_existing_bucket` var.