### PR TITLE
fix: restrict runner security group to only ingress

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -185,6 +185,8 @@ resource "aws_security_group" "runner_sg" {
 
   vpc_id = var.vpc_id
 
+  ingress = []
+
   dynamic "egress" {
     for_each = var.egress_rules
     iterator = each


### PR DESCRIPTION
Runner security group is currently open.

This patch removes the default ingress rule security group to deny everything.

More info on [this documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#removing-all-ingress-and-egress-rules).