### PR TITLE
docs: Correct link to slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,4 +157,4 @@ Use the badge to sign-up.
 
 [contribute]: CONTRIBUTING.md
 [github]: https://github.com/philips-labs/terraform-aws-github-runner/issues
-[slack]: https://philips-software.slack.com/home
+[slack]: https://join.slack.com/t/philips-software/shared_invite/zt-xecw65v5-i1531hGP~mdVwgxLFx7ckg


### PR DESCRIPTION
# Description

Update Slack link in CONTRIBUTING 

## Related issue

Closes: #3576