### PR TITLE
Added Network Interface Configuration to Runners Module

### DIFF
--- a/modules/runners/README.md
+++ b/modules/runners/README.md
@@ -10,6 +10,17 @@ This module creates resources required to run the GitHub action runner on AWS EC
 
 The action runners are created via a launch template; in the launch template only the subnet needs to be provided. During launch the installation is handled via a user data script. The configuration is fetched from SSM parameter store.
 
+### Network Interface Configuration
+
+You can control whether a public IP address should be associated with the EC2 instance using the `associate_public_ip_address` variable. Here is an example of how you can configure it:
+
+```hcl
+module "runners" {
+  ...
+  associate_public_ip_address = true
+  ...
+}
+```
 ### Lambda scale up
 
 The scale up lambda is triggered by events on a SQS queue. Events on this queue are delayed, which will give the workflow some time to start running on available runners. For each event the lambda will check if the workflow is still queued and no other limits are reached. In that case the lambda will create a new EC2 instance. The lambda only needs to know which launch template to use and which subnets are available. From the available subnets a random one will be chosen. Once the instance is created the event is assumed as handled, and we assume the workflow wil start at some moment once the created instance is ready.

--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -173,6 +173,10 @@ resource "aws_launch_template" "runner" {
     ssm_key_cloudwatch_agent_config = var.enable_cloudwatch_agent ? aws_ssm_parameter.cloudwatch_agent_config_runner[0].name : ""
   })) : ""
 
+  network_interfaces {
+    associate_public_ip_address = var.associate_public_ip_address
+  }
+
   tags = local.tags
 
   update_default_version = true

--- a/modules/runners/variables.tf
+++ b/modules/runners/variables.tf
@@ -622,3 +622,9 @@ variable "enable_jit_config" {
   type        = bool
   default     = null
 }
+
+variable "associate_public_ip_address" {
+  description = "Indicates whether a public IP address should be associated with the EC2 instance."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This pull request introduces an option to associate a public IP address with the EC2 instance created for the GitHub runner. 

The modification includes an additional variable associate_public_ip_address in the variables.tf file and references this variable in the main.tf file under the network_interfaces block for the EC2 instance configuration within the runners module.
Additionally, documentation has been updated in the README.md of the runners module to explain the new configuration option.

This change allows for better flexibility when deploying runners in different network environments. In scenarios where a public IP is not required or preferred due to security or cost considerations, this option can now be toggled off.