### PR TITLE
feat(main): Make configuration parameters of type SSM SecureString

### DIFF
--- a/modules/runners/logging.tf
+++ b/modules/runners/logging.tf
@@ -43,7 +43,7 @@ locals {
 resource "aws_ssm_parameter" "cloudwatch_agent_config_runner" {
   count = var.enable_cloudwatch_agent ? 1 : 0
   name  = "${var.ssm_paths.root}/${var.ssm_paths.config}/cloudwatch_agent_config_runner"
-  type  = "String"
+  type  = "SecureString"
   value = var.cloudwatch_config != null ? var.cloudwatch_config : templatefile("${path.module}/templates/cloudwatch_config.json", {
     logfiles = jsonencode(local.logfiles)
   })

--- a/modules/runners/runner-config.tf
+++ b/modules/runners/runner-config.tf
@@ -1,34 +1,34 @@
 resource "aws_ssm_parameter" "runner_config_run_as" {
   name  = "${var.ssm_paths.root}/${var.ssm_paths.config}/run_as"
-  type  = "String"
+  type  = "SecureString"
   value = var.runner_as_root ? "root" : var.runner_run_as
   tags  = local.tags
 }
 
 resource "aws_ssm_parameter" "runner_agent_mode" {
   name  = "${var.ssm_paths.root}/${var.ssm_paths.config}/agent_mode"
-  type  = "String"
+  type  = "SecureString"
   value = var.enable_ephemeral_runners ? "ephemeral" : "persistent"
   tags  = local.tags
 }
 
 resource "aws_ssm_parameter" "jit_config_enabled" {
   name  = "${var.ssm_paths.root}/${var.ssm_paths.config}/enable_jit_config"
-  type  = "String"
+  type  = "SecureString"
   value = var.enable_jit_config == null ? var.enable_ephemeral_runners : var.enable_jit_config
   tags  = local.tags
 }
 
 resource "aws_ssm_parameter" "runner_enable_cloudwatch" {
   name  = "${var.ssm_paths.root}/${var.ssm_paths.config}/enable_cloudwatch"
-  type  = "String"
+  type  = "SecureString"
   value = var.enable_cloudwatch_agent
   tags  = local.tags
 }
 
 resource "aws_ssm_parameter" "token_path" {
   name  = "${var.ssm_paths.root}/${var.ssm_paths.config}/token_path"
-  type  = "String"
+  type  = "SecureString"
   value = "${var.ssm_paths.root}/${var.ssm_paths.tokens}"
   tags  = local.tags
 }


### PR DESCRIPTION
It is understandable to keep non-sensitive configuration information as a plain SSM `String`, however for the purposes of SOC2 compliance in our organisation, we need to make all SSM Parameters encrypted.

This PR changes the type for the below SSM parameters so that they are `SecureString`:
- `"${var.ssm_paths.root}/${var.ssm_paths.config}/cloudwatch_agent_config_runner"`
- `"${var.ssm_paths.root}/${var.ssm_paths.config}/run_as"`
- `"${var.ssm_paths.root}/${var.ssm_paths.config}/agent_mode"`
- `"${var.ssm_paths.root}/${var.ssm_paths.config}/enable_jit_config"`
- `"${var.ssm_paths.root}/${var.ssm_paths.config}/enable_cloudwatch"`
- `"${var.ssm_paths.root}/${var.ssm_paths.config}/token_path"`