### PR TITLE
fix(examples): webhook-github-app multiple character args

### DIFF
--- a/modules/webhook-github-app/bin/update-app.sh
+++ b/modules/webhook-github-app/bin/update-app.sh
@@ -23,21 +23,21 @@ usages() {
     echo "  -a APP_ID                    GitHub App ID" >&2
     echo "  -k APP_PRIVATE_KEY_BASE64    Base64 encoded private key of the GitHub App" >&2
     echo "  -f APP APP_PRIVATE_KEY_FILE  Path to the private key of the GitHub App" >&2
-    echo "  -we WEBHOOK_ENDPOINT         Webhook endpoint" >&2
-    echo "  -ws WEBHOOK_SECRET           Webhook secret" >&2
+    echo "  -e WEBHOOK_ENDPOINT          Webhook endpoint" >&2
+    echo "  -s WEBHOOK_SECRET            Webhook secret" >&2
     echo "  -h                           Show this help message" >&2
     exit 1
 }
 
 # hadd h flag to show help
-while getopts a:f:k:ws:we:h flag
+while getopts a:f:k:s:e:h flag
 do
     case "${flag}" in
         a) APP_ID=${OPTARG};;
         f) APP_PRIVATE_KEY_FILE=${OPTARG};;
         k) APP_PRIVATE_KEY_BASE64=${OPTARG};;
-        we) WEBHOOK_ENDPOINT=${OPTARG};;
-        ws) WEBHOOK_SECRET=${OPTARG};;
+        e) WEBHOOK_ENDPOINT=${OPTARG};;
+        s) WEBHOOK_SECRET=${OPTARG};;
         h) usages ;;
     esac
 done

--- a/modules/webhook-github-app/main.tf
+++ b/modules/webhook-github-app/main.tf
@@ -6,7 +6,7 @@ resource "null_resource" "update_app" {
 
   provisioner "local-exec" {
     interpreter = ["bash", "-c"]
-    command     = "${path.module}/bin/update-app.sh -we ${var.webhook_endpoint} -ws ${var.github_app.webhook_secret} -a ${var.github_app.id} -k ${var.github_app.key_base64}"
+    command     = "${path.module}/bin/update-app.sh -e ${var.webhook_endpoint} -s ${var.github_app.webhook_secret} -a ${var.github_app.id} -k ${var.github_app.key_base64}"
     on_failure  = continue
   }
 }


### PR DESCRIPTION
## What
* Change to `webhook-github-app` to use single character options

## Why

The module fails silently, but bash `getopts` does not support multicharacter options this changes that to use single character options instead.

## References
* fixes: #3556
* https://stackoverflow.com/questions/3975004/how-to-make-a-multi-character-parameter-in-unix-using-getopt
* https://unix.stackexchange.com/questions/684717/how-to-use-getopts-in-bash
* https://stackoverflow.com/questions/402377/using-getopts-to-process-long-and-short-command-line-options