### PR TITLE
feat: Custom Trigger for downloading lambdas

### DIFF
--- a/modules/download-lambda/main.tf
+++ b/modules/download-lambda/main.tf
@@ -2,9 +2,10 @@ resource "null_resource" "download" {
   count = length(var.lambdas)
 
   triggers = {
-    name = var.lambdas[count.index].name
-    file = "${var.lambdas[count.index].name}.zip"
-    tag  = var.lambdas[count.index].tag
+    name           = var.lambdas[count.index].name
+    file           = "${var.lambdas[count.index].name}.zip"
+    tag            = var.lambdas[count.index].tag
+    custom_trigger = var.custom_trigger
   }
 
   provisioner "local-exec" {

--- a/modules/download-lambda/variables.tf
+++ b/modules/download-lambda/variables.tf
@@ -5,3 +5,9 @@ variable "lambdas" {
     tag  = string
   }))
 }
+
+variable "custom_trigger" {
+  description = "Custom trigger for fetching lambda."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## What
 
* Adds an optional variable that can be used to resync the zips at customers discretion

## Why

The fetch lambdas is intended to be a dependency of the core `github-runners` module that fetches the lambdas to the `${path.module}` for easy access to the lambda zips. Managing the download of this zip with terraform presents a problem where the first run succeeds. If the zips are .gitignored and cleaned out however, future runs will fail - as the state says the fetch was successful, but locally the zips no longer exist

Similarly if ran on CICD, we would like to be able to control how often this fetch is made. Thus a custom trigger variable would allow customers to use whatever trigger they want and pass it through to your module.

examples could be:
 * `timestamp()` - always
 * `join(",", [fileexists("runners.zip"), fileexists("webhook.zip")])`

## References
* N/A