### PR TITLE
fix: Re-add support for runners without public IP

### DIFF
--- a/modules/runners/main.tf
+++ b/modules/runners/main.tf
@@ -121,11 +121,6 @@ resource "aws_launch_template" "runner" {
   key_name                             = var.key_name
   ebs_optimized                        = var.ebs_optimized
 
-  vpc_security_group_ids = !var.associate_public_ipv4_address ? compact(concat(
-    var.enable_managed_runner_security_group ? [aws_security_group.runner_sg[0].id] : [],
-    var.runner_additional_security_group_ids,
-  )) : []
-
   tag_specifications {
     resource_type = "instance"
     tags = merge(
@@ -179,16 +174,12 @@ resource "aws_launch_template" "runner" {
 
   update_default_version = true
 
-  dynamic "network_interfaces" {
-    for_each = var.associate_public_ipv4_address ? [var.associate_public_ipv4_address] : []
-    iterator = associate_public_ipv4_address
-    content {
-      associate_public_ip_address = associate_public_ipv4_address.value
-      security_groups = compact(concat(
-        var.enable_managed_runner_security_group ? [aws_security_group.runner_sg[0].id] : [],
-        var.runner_additional_security_group_ids,
-      ))
-    }
+  network_interfaces {
+    associate_public_ip_address = var.associate_public_ipv4_address
+    security_groups = compact(concat(
+      var.enable_managed_runner_security_group ? [aws_security_group.runner_sg[0].id] : [],
+      var.runner_additional_security_group_ids,
+    ))
   }
 }
 


### PR DESCRIPTION
Hello,

Per our testing, EC2 runner instances are always created with a public IP after #3547, even when this is not requested. This seems to be due to the conditional inclusion of a network interface in the launch template - if public IPv4 is not requested, there is no interface defined in the template, and instances are launched with a default one that includes a public IP.