### PR TITLE
fix(images): avoid wrong AMI selected for ubuntu jammy

### DIFF
--- a/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
@@ -106,7 +106,7 @@ source "amazon-ebs" "githubrunner" {
 
   source_ami_filter {
     filters = {
-      name                = "*/ubuntu-jammy-22.04-arm64-server-*"
+      name                = "*ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }

--- a/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
@@ -106,7 +106,7 @@ source "amazon-ebs" "githubrunner" {
 
   source_ami_filter {
     filters = {
-      name                = "*/ubuntu-jammy-22.04-amd64-server-*"
+      name                = "*ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }


### PR DESCRIPTION
This PR fixes the exact same issue as: https://github.com/philips-labs/terraform-aws-github-runner/pull/2214

but for ubuntu jammy instead.

Using the aws cli we can see Canonical have published eks images which match the old ami filter:

```
$ aws ec2 describe-images --owners "099720109477" --filters "Name=name,Values=*/ubuntu-jammy-22.04-amd64-server-*" "Name=root-device-type,Values=ebs" "Name=virtualization-type,Values=hvm" --query 'reverse(sort_by(Images,&CreationDate))[:10].{id:ImageId,date:CreationDate,name:Name}'
[
    {
        "id": "ami-076c5927ad06134ea",
        "date": "2024-02-01T14:32:11.000Z",
        "name": "ubuntu-eks/k8s_1.29/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240201"
    },
    {
        "id": "ami-01daded1d6569f09c",
        "date": "2024-01-31T23:50:34.000Z",
        "name": "ubuntu-eks/k8s_1.29/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240131"
    },
    {
        "id": "ami-0f244b28200b93640",
        "date": "2024-01-26T02:50:50.000Z",
        "name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240126"
    },
...
```

which causes the ami build to flip-flop between the standard Ubuntu server and the EKS optimised one (which is lacking in several tools) causing workflows to fail with unexpected errors.

The updated filter returns only the expected images:
```
$ aws ec2 describe-images --owners "099720109477" --filters "Name=name,Values=*ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*" "Name=root-device-type,Values=ebs" "Name=virtualization-type,Values=hvm" --query 'reverse(sort_by(Images,&CreationDate))[:10].{id:ImageId,date:CreationDate,name:Name}'
[
    {
        "id": "ami-0f244b28200b93640",
        "date": "2024-01-26T02:50:50.000Z",
        "name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240126"
    },
    {
        "id": "ami-03559713c297ec8fb",
        "date": "2024-01-25T02:42:50.000Z",
        "name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240125"
    },
    {
        "id": "ami-0aad72a0b9d9baec1",
        "date": "2024-01-24T11:01:15.000Z",
        "name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240124"
    },
...
```