### PR TITLE
fix(provider): Updated the version requirements for the hashicorp/null provider consistent across the submodules

### DIFF
--- a/modules/download-lambda/versions.tf
+++ b/modules/download-lambda/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.0"
+      version = "~> 3.2"
     }
   }
 }

--- a/modules/webhook-github-app/versions.tf
+++ b/modules/webhook-github-app/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     null = {
       source  = "hashicorp/null"
-      version = "~> 3"
+      version = "~> 3.2"
     }
   }
 }


### PR DESCRIPTION
# What

- Updated the version requirements for the hashicorp/null provider consistent across the submodules

# Why

- To make the submodule work with one another 
# Reference

```
~>: Allows only the rightmost version component to increment. This format is referred to as the pessimistic constraint operator. For example, to allow new patch releases within a specific minor release, use the full version number:

    ~> 1.0.4: Allows Terraform to install 1.0.5 and 1.0.10 but not 1.1.0.
    ~> 1.1: Allows Terraform to install 1.2 and 1.10 but not 2.0. 
```