### PR TITLE
fix(images): the EC2launch script for windows packer images

### DIFF
--- a/images/windows-core-2019/windows-provisioner.ps1
+++ b/images/windows-core-2019/windows-provisioner.ps1
@@ -49,4 +49,17 @@ $action = New-ScheduledTaskAction -WorkingDirectory "C:\actions-runner" -Execute
 $trigger = New-ScheduledTaskTrigger -AtStartup
 Register-ScheduledTask -TaskName "runnerinit" -Action $action -Trigger $trigger -User System -RunLevel Highest -Force
 
-C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 -Schedule
+$EC2LaunchFolder = "C:\EC2Launch"
+New-Item -ItemType Directory -Force -Path $EC2LaunchFolder
+
+$Url = "https://s3.amazonaws.com/ec2-downloads-windows/EC2Launch/latest/EC2-Windows-Launch.zip"
+$DownloadZipFile = Join-Path -Path $EC2LaunchFolder -ChildPath $(Split-Path -Path $Url -Leaf)
+Invoke-WebRequest -Uri $Url -OutFile $DownloadZipFile
+
+$Url = "https://s3.amazonaws.com/ec2-downloads-windows/EC2Launch/latest/install.ps1"
+$DownloadInstallFile = Join-Path -Path $EC2LaunchFolder -ChildPath $(Split-Path -Path $Url -Leaf)
+Invoke-WebRequest -Uri $Url -OutFile $DownloadInstallFile
+
+& $DownloadInstallFile
+
+& "C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1" -Schedule

--- a/images/windows-core-2022/windows-provisioner.ps1
+++ b/images/windows-core-2022/windows-provisioner.ps1
@@ -49,4 +49,17 @@ $action = New-ScheduledTaskAction -WorkingDirectory "C:\actions-runner" -Execute
 $trigger = New-ScheduledTaskTrigger -AtStartup
 Register-ScheduledTask -TaskName "runnerinit" -Action $action -Trigger $trigger -User System -RunLevel Highest -Force
 
-C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 -Schedule
+$EC2LaunchFolder = "C:\EC2Launch"
+New-Item -ItemType Directory -Force -Path $EC2LaunchFolder
+
+$Url = "https://s3.amazonaws.com/ec2-downloads-windows/EC2Launch/latest/EC2-Windows-Launch.zip"
+$DownloadZipFile = Join-Path -Path $EC2LaunchFolder -ChildPath $(Split-Path -Path $Url -Leaf)
+Invoke-WebRequest -Uri $Url -OutFile $DownloadZipFile
+
+$Url = "https://s3.amazonaws.com/ec2-downloads-windows/EC2Launch/latest/install.ps1"
+$DownloadInstallFile = Join-Path -Path $EC2LaunchFolder -ChildPath $(Split-Path -Path $Url -Leaf)
+Invoke-WebRequest -Uri $Url -OutFile $DownloadInstallFile
+
+& $DownloadInstallFile
+
+& "C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1" -Schedule


### PR DESCRIPTION
### Problem
---

The current windows provisioner fails when building custom images with packer. The `InitializeInstance.ps1` script can't be detected and causes the image build to fail. See the error output.



### Solution
---

Download the latest EC2Launch powershell scripts per https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch.html

### Reproduce
---
`packer init .`
`packer build github_agent.windows.pkr.hcl`

### Error Message
---
```    githubactions-runner.amazon-ebs.githubrunner: Downloading the GH Action runner from https://github.com/actions/runner/releases/download/v2.315.0/actions-runner-win-x64-2.315.0.zip
    githubactions-runner.amazon-ebs.githubrunner: VERBOSE: GET https://github.com/actions/runner/releases/download/v2.315.0/actions-runner-win-x64-2.315.0.zip with
    githubactions-runner.amazon-ebs.githubrunner: 0-byte payload
    githubactions-runner.amazon-ebs.githubrunner: VERBOSE: received 88712370-byte response of content type application/octet-stream
    githubactions-runner.amazon-ebs.githubrunner: Un-zip action runner
    githubactions-runner.amazon-ebs.githubrunner: Delete zip file
    githubactions-runner.amazon-ebs.githubrunner:
    githubactions-runner.amazon-ebs.githubrunner: Actions            : {MSFT_TaskExecAction}
    githubactions-runner.amazon-ebs.githubrunner: Author             :
    githubactions-runner.amazon-ebs.githubrunner: Date               :
    githubactions-runner.amazon-ebs.githubrunner: Description        :
    githubactions-runner.amazon-ebs.githubrunner: Documentation      :
    githubactions-runner.amazon-ebs.githubrunner: Principal          : MSFT_TaskPrincipal2
==> githubactions-runner.amazon-ebs.githubrunner: C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 : The term
    githubactions-runner.amazon-ebs.githubrunner: SecurityDescriptor :
    githubactions-runner.amazon-ebs.githubrunner: Settings           : MSFT_TaskSettings3
==> githubactions-runner.amazon-ebs.githubrunner: 'C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1' is not recognized as the name of a cmdlet,
    githubactions-runner.amazon-ebs.githubrunner: Source             :
    githubactions-runner.amazon-ebs.githubrunner: State              : Ready
==> githubactions-runner.amazon-ebs.githubrunner: function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the
==> githubactions-runner.amazon-ebs.githubrunner: path is correct and try again.
==> githubactions-runner.amazon-ebs.githubrunner: At C:\Windows\Temp\script-66103df7-87a6-e332-a678-ece8ade44494.ps1:52 char:1
==> githubactions-runner.amazon-ebs.githubrunner: + C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.p ...
==> githubactions-runner.amazon-ebs.githubrunner: + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    githubactions-runner.amazon-ebs.githubrunner: TaskName           : runnerinit
==> githubactions-runner.amazon-ebs.githubrunner:     + CategoryInfo          : ObjectNotFound: (C:\ProgramData\...izeInstance.ps1:String) [], CommandNotFoundException
==> githubactions-runner.amazon-ebs.githubrunner:     + FullyQualifiedErrorId : CommandNotFoundException
==> githubactions-runner.amazon-ebs.githubrunner:
    githubactions-runner.amazon-ebs.githubrunner: TaskPath           : \
    githubactions-runner.amazon-ebs.githubrunner: Triggers           : {MSFT_TaskBootTrigger}
    githubactions-runner.amazon-ebs.githubrunner: URI                : \runnerinit
    githubactions-runner.amazon-ebs.githubrunner: Version            :
    githubactions-runner.amazon-ebs.githubrunner: PSComputerName     :
    githubactions-runner.amazon-ebs.githubrunner:```
    



