### PR TITLE
fix: change log level for termination watcher if no match

### DIFF
--- a/lambdas/functions/termination-watcher/src/lambda.test.ts
+++ b/lambdas/functions/termination-watcher/src/lambda.test.ts
@@ -7,7 +7,6 @@ import { interruptionWarning } from './lambda';
 import { SpotInterruptionWarning, SpotTerminationDetail } from './types';
 
 jest.mock('./termination-warning');
-//jest.mock('@terraform-aws-github-runner/aws-powertools-util');
 
 process.env.POWERTOOLS_METRICS_NAMESPACE = 'test';
 process.env.POWERTOOLS_TRACE_ENABLED = 'true';

--- a/lambdas/functions/termination-watcher/src/termination-warning.ts
+++ b/lambdas/functions/termination-watcher/src/termination-warning.ts
@@ -49,7 +49,7 @@ async function handle(event: SpotInterruptionWarning<SpotTerminationDetail>, con
       );
     }
   } else {
-    logger.warn(
+    logger.debug(
       `Received spot termination notification warning for instance ${event.detail['instance-id']} but ` +
         `details are not available or instance not matching the tag fileter (${config.tagFilters}).`,
     );


### PR DESCRIPTION
Changed log level to debug in case no match. Deploying the lambda multiple times in a single aws account will create unrelated warning logs otherwise.