### PR TITLE
fix: adding missing permissions to boundaries

### DIFF
--- a/modules/setup-iam-permissions/policies/deploy-boundary.json
+++ b/modules/setup-iam-permissions/policies/deploy-boundary.json
@@ -52,7 +52,8 @@
         "iam:RemoveRoleFromInstanceProfile",
         "iam:DeleteInstanceProfile",
         "iam:AddRoleToInstanceProfile",
-        "iam:GetInstanceProfile"
+        "iam:GetInstanceProfile",
+        "iam:TagInstanceProfile"
       ],
       "Resource": "arn:${aws_partition}:iam::${account_id}:instance-profile/${instance_profile_namespace}/*"
     },


### PR DESCRIPTION
`setup-iam-permissions`: add missing `iam:TagInstanceProfile` required for `aws_iam_instance_profile "runner"`

The `aws_iam_instance_profile` resource in https://github.com/philips-labs/terraform-aws-github-runner/blob/74471de59ac97748581612efa62c3950344916f4/modules/runners/policies-runner.tf#L11-L16 requires the `iam:TagInstanceProfile` permission.