### PR TITLE
fix: Typo in env vars for scale-up lambda

### DIFF
--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "scale_up" {
       RUNNER_GROUP_NAME                        = var.runner_group_name
       RUNNER_NAME_PREFIX                       = var.runner_name_prefix
       RUNNERS_MAXIMUM_COUNT                    = var.runners_maximum_count
-      PWOERTOOLS_SERVICE_NAME                  = "runners-scale-up"
+      POWERTOOLS_SERVICE_NAME                  = "runners-scale-up"
       SSM_TOKEN_PATH                           = local.token_path
       SSM_CONFIG_PATH                          = "${var.ssm_paths.root}/${var.ssm_paths.config}"
       SUBNET_IDS                               = join(",", var.subnet_ids)


### PR DESCRIPTION
Fixes https://github.com/philips-labs/terraform-aws-github-runner/issues/3886