### PR TITLE
fix: improve logging when there is an error retrieving ssm parameters

### DIFF
--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -210,7 +210,8 @@ async function getAmiIdOverride(runnerParameters: Runners.RunnerInputParameters)
         'Please ensure that the given parameter exists on this region and contains a valid runner AMI ID',
       { error: e },
     );
-    throw e;
+    throw new Error(`Failed to lookup runner AMI ID from SSM parameter: ${runnerParameters.amiIdSsmParameterName},
+       ${e}`);
   }
 }
 

--- a/lambdas/functions/control-plane/src/lambda.ts
+++ b/lambdas/functions/control-plane/src/lambda.ts
@@ -24,7 +24,7 @@ export async function scaleUpHandler(event: SQSEvent, context: Context): Promise
     if (e instanceof ScaleError) {
       throw e;
     } else {
-      logger.warn(`Ignoring error: ${(e as Error).message}`);
+      logger.warn(`Ignoring error: ${e}`);
     }
   }
 }


### PR DESCRIPTION
In case the AMI ID Parameter was set to something that did not exist, it would produce an obscure error: "message": "Ignoring error: UnknownError".
Now it produces better error messages:
"message": "Ignoring error: Error: Failed to lookup runner AMI ID from SSM parameter: /github-action-runners/staging/ubuntu-x64/runners/config/ami-id,\n       ParameterNotFound: UnknownError",


Signed-off-by: Brend Smits <brend.smits@philips.com>