### PR TITLE
fix: add warnings to log for GitHub rate limits

### DIFF
--- a/lambdas/functions/control-plane/jest.config.ts
+++ b/lambdas/functions/control-plane/jest.config.ts
@@ -6,10 +6,10 @@ const config: Config = {
   ...defaultConfig,
   coverageThreshold: {
     global: {
-      statements: 97.99,
-      branches: 96.04,
-      functions: 97.53,
-      lines: 98.3,
+      statements: 97.79,
+      branches: 96.13,
+      functions: 95.4,
+      lines: 98.06,
     },
   },
 };

--- a/lambdas/functions/control-plane/package.json
+++ b/lambdas/functions/control-plane/package.json
@@ -42,6 +42,7 @@
     "@aws-sdk/types": "^3.433.0",
     "@middy/core": "^4.7.0",
     "@octokit/auth-app": "6.0.3",
+    "@octokit/plugin-throttling": "8.1.3",
     "@octokit/rest": "20.0.2",
     "@octokit/types": "^13.5.0",
     "@terraform-aws-github-runner/aws-powertools-util": "*",

--- a/lambdas/functions/control-plane/src/gh-auth/gh-auth.ts
+++ b/lambdas/functions/control-plane/src/gh-auth/gh-auth.ts
@@ -18,7 +18,6 @@ import { axiosFetch } from '../axios/fetch-override';
 
 const logger = createChildLogger('gh-auth');
 
-
 export async function createOctoClient(token: string, ghesApiUrl = ''): Promise<Octokit> {
   const CustomOctokit = Octokit.plugin(throttling);
   const ocktokitOptions: OctokitOptions = {
@@ -39,9 +38,7 @@ export async function createOctoClient(token: string, ghesApiUrl = ''): Promise<
         );
       },
       onSecondaryRateLimit: (retryAfter, options) => {
-        logger.warn(
-          `GitHub rate limit: SecondaryRateLimit detected for request ${options.method} ${options.url}`,
-        );
+        logger.warn(`GitHub rate limit: SecondaryRateLimit detected for request ${options.method} ${options.url}`);
       },
     },
   });

--- a/lambdas/functions/control-plane/src/gh-auth/gh-auth.ts
+++ b/lambdas/functions/control-plane/src/gh-auth/gh-auth.ts
@@ -10,13 +10,17 @@ import {
 import { OctokitOptions } from '@octokit/core/dist-types/types';
 import { request } from '@octokit/request';
 import { Octokit } from '@octokit/rest';
+import { throttling } from '@octokit/plugin-throttling';
 import { createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
 import { getParameter } from '@terraform-aws-github-runner/aws-ssm-util';
 
 import { axiosFetch } from '../axios/fetch-override';
 
 const logger = createChildLogger('gh-auth');
+
+
 export async function createOctoClient(token: string, ghesApiUrl = ''): Promise<Octokit> {
+  const CustomOctokit = Octokit.plugin(throttling);
   const ocktokitOptions: OctokitOptions = {
     auth: token,
     request: { fetch: axiosFetch },
@@ -25,7 +29,22 @@ export async function createOctoClient(token: string, ghesApiUrl = ''): Promise<
     ocktokitOptions.baseUrl = ghesApiUrl;
     ocktokitOptions.previews = ['antiope'];
   }
-  return new Octokit(ocktokitOptions);
+
+  return new CustomOctokit({
+    ...ocktokitOptions,
+    throttle: {
+      onRateLimit: (retryAfter, options) => {
+        logger.warn(
+          `GitHub rate limit: Request quota exhausted for request ${options.method} ${options.url}. Requested `,
+        );
+      },
+      onSecondaryRateLimit: (retryAfter, options) => {
+        logger.warn(
+          `GitHub rate limit: SecondaryRateLimit detected for request ${options.method} ${options.url}`,
+        );
+      },
+    },
+  });
 }
 
 export async function createGithubAppAuth(

--- a/lambdas/yarn.lock
+++ b/lambdas/yarn.lock
@@ -2736,6 +2736,14 @@
   dependencies:
     "@octokit/types" "^12.0.0"
 
+"@octokit/plugin-throttling@8.1.3":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-throttling/-/plugin-throttling-8.1.3.tgz#7fb0e001c0cb9383c6be07740b8ec326ed990f6b"
+  integrity sha512-pfyqaqpc0EXh5Cn4HX9lWYsZ4gGbjnSmUILeu4u2gnuM50K/wIk9s1Pxt3lVeVwekmITgN/nJdoh43Ka+vye8A==
+  dependencies:
+    "@octokit/types" "^12.2.0"
+    bottleneck "^2.15.3"
+
 "@octokit/request-error@^5.0.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-5.1.0.tgz#ee4138538d08c81a60be3f320cd71063064a3b30"
@@ -2766,7 +2774,7 @@
     "@octokit/plugin-request-log" "^4.0.0"
     "@octokit/plugin-rest-endpoint-methods" "^10.0.0"
 
-"@octokit/types@^11.0.0", "@octokit/types@^11.1.0", "@octokit/types@^12.0.0", "@octokit/types@^13.0.0", "@octokit/types@^13.1.0", "@octokit/types@^13.5.0":
+"@octokit/types@^11.0.0", "@octokit/types@^11.1.0", "@octokit/types@^12.0.0", "@octokit/types@^12.2.0", "@octokit/types@^13.0.0", "@octokit/types@^13.1.0", "@octokit/types@^13.5.0":
   version "13.5.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-13.5.0.tgz#4796e56b7b267ebc7c921dcec262b3d5bfb18883"
   integrity sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==
@@ -4322,6 +4330,11 @@ body-parser@1.20.2, body-parser@^1.20.2:
     raw-body "2.5.2"
     type-is "~1.6.18"
     unpipe "1.0.0"
+
+bottleneck@^2.15.3:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
 bowser@^2.11.0:
   version "2.11.0"


### PR DESCRIPTION
Adding explicit logging for GitHub reate limits. No retries implemented. Only for abuse retrying seems an option. In other cases a retry will take to long given lambda timeouts taken into accont.