### PR TITLE
feat(webhook): Enable authorizer assignment to webhook

### DIFF
--- a/modules/webhook/main.tf
+++ b/modules/webhook/main.tf
@@ -17,7 +17,8 @@ resource "aws_apigatewayv2_route" "webhook" {
 
   lifecycle {
     ignore_changes = [
-      # ignore authorization related attributes to enable authenticator assignment to API route
+      # Ignore authorization related attributes to enable authenticator assignment to API route.
+      # NOTE: We consider the ignores as a system intenral. Future changes will not trigger a breakig change.
       authorizer_id,
       authorization_type,
       authorization_scopes,

--- a/modules/webhook/main.tf
+++ b/modules/webhook/main.tf
@@ -14,6 +14,15 @@ resource "aws_apigatewayv2_route" "webhook" {
   api_id    = aws_apigatewayv2_api.webhook.id
   route_key = "POST /${local.webhook_endpoint}"
   target    = "integrations/${aws_apigatewayv2_integration.webhook.id}"
+
+  lifecycle {
+    ignore_changes = [
+      # ignore authorization related attributes to enable authenticator assignment to API route
+      authorizer_id,
+      authorization_type,
+      authorization_scopes,
+    ]
+  }
 }
 
 resource "aws_apigatewayv2_stage" "webhook" {


### PR DESCRIPTION
We want to add a lambda authenticator to webhook API endpoint to restrict requests by source IP address. To achieve this, the following two options are possible:

1. add attributes to pass authorizer resource information to this module,
2. or simply ignores changes related to authorizer of `aws_apigatewayv2_route` resource,

However, 1. requires all informations to create `aws_apigatewayv2_authorizer` and `aws_lambda_permission`, this is little bit need consideration. Option 2. is, of cource, needs resouce update by hand, however, the very simple to achieve by ignoring attribute changes.

This PR aims to implement option 2.