### PR TITLE
fix: upgrade aws powertools to v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,11 +27,11 @@ updates:
       octokit:
         patterns:
           - "@octokit/*"
+      aws-powertools:
+        patterns:
+          - "@aws-lambda-powertools/*"
+
     ignore:
-      - dependency-name: "aws-sdk*"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "aws-lambda-powertools/*"
-        update-types: ["version-update:semver-major"]
       - dependency-name: "@middy/core"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@octokit/*"

--- a/lambdas/functions/termination-watcher/src/lambda.ts
+++ b/lambdas/functions/termination-watcher/src/lambda.ts
@@ -6,7 +6,7 @@ import {
   setContext,
   tracer,
 } from '@terraform-aws-github-runner/aws-powertools-util';
-import { logMetrics } from '@aws-lambda-powertools/metrics';
+import { logMetrics } from '@aws-lambda-powertools/metrics/middleware';
 import { Context } from 'aws-lambda';
 
 import { handle as handleTerminationWarning } from './termination-warning';

--- a/lambdas/functions/termination-watcher/src/termination-warning.test.ts
+++ b/lambdas/functions/termination-watcher/src/termination-warning.test.ts
@@ -4,7 +4,7 @@ import 'aws-sdk-client-mock-jest';
 import { handle } from './termination-warning';
 import { SpotInterruptionWarning, SpotTerminationDetail } from './types';
 import { createSingleMetric } from '@terraform-aws-github-runner/aws-powertools-util';
-import { MetricUnits } from '@aws-lambda-powertools/metrics';
+import { MetricUnit } from '@aws-lambda-powertools/metrics';
 
 jest.mock('@terraform-aws-github-runner/aws-powertools-util', () => ({
   ...jest.requireActual('@terraform-aws-github-runner/aws-powertools-util'),
@@ -63,7 +63,7 @@ describe('handle termination warning', () => {
 
     await handle(event, config);
     expect(createSingleMetric).toHaveBeenCalled();
-    expect(createSingleMetric).toHaveBeenCalledWith('SpotInterruptionWarning', MetricUnits.Count, 1, {
+    expect(createSingleMetric).toHaveBeenCalledWith('SpotInterruptionWarning', MetricUnit.Count, 1, {
       InstanceType: instance.InstanceType ? instance.InstanceType : '_FAIL_',
       Environment: instance.Tags?.find((tag) => tag.Key === 'ghr:environment')?.Value ?? '_FAIL_',
     });

--- a/lambdas/functions/termination-watcher/src/termination-warning.ts
+++ b/lambdas/functions/termination-watcher/src/termination-warning.ts
@@ -6,7 +6,7 @@ import {
 import { SpotInterruptionWarning, SpotTerminationDetail } from './types';
 import { DescribeInstancesCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { Config } from './ConfigResolver';
-import { MetricUnits } from '@aws-lambda-powertools/metrics';
+import { MetricUnit } from '@aws-lambda-powertools/metrics';
 
 const logger = createChildLogger('termination-warning');
 
@@ -37,7 +37,7 @@ async function handle(event: SpotInterruptionWarning<SpotTerminationDetail>, con
       tags: instance.Tags,
     });
     if (config.createSpotWarningMetric) {
-      const metric = createSingleMetric('SpotInterruptionWarning', MetricUnits.Count, 1, {
+      const metric = createSingleMetric('SpotInterruptionWarning', MetricUnit.Count, 1, {
         InstanceType: instance.InstanceType ? instance.InstanceType : 'unknown',
         Environment: instance.Tags?.find((tag) => tag.Key === 'ghr:environment')?.Value ?? 'unknown',
       });

--- a/lambdas/libs/aws-powertools-util/package.json
+++ b/lambdas/libs/aws-powertools-util/package.json
@@ -35,9 +35,9 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@aws-lambda-powertools/logger": "^1.18.1",
-    "@aws-lambda-powertools/metrics": "^1.18.1",
-    "@aws-lambda-powertools/tracer": "^1.18.1",
+    "@aws-lambda-powertools/logger": "^2.6.0",
+    "@aws-lambda-powertools/metrics": "^2.6.0",
+    "@aws-lambda-powertools/tracer": "^2.6.0",
     "aws-lambda": "^1.0.7"
   },
   "nx": {

--- a/lambdas/libs/aws-powertools-util/src/metrics/index.ts
+++ b/lambdas/libs/aws-powertools-util/src/metrics/index.ts
@@ -1,5 +1,5 @@
 import { Metrics } from '@aws-lambda-powertools/metrics';
-import { MetricUnits } from '@aws-lambda-powertools/metrics/lib/types';
+import { MetricUnit } from '@aws-lambda-powertools/metrics/types';
 
 export const metrics = new Metrics({
   defaultDimensions: {},
@@ -7,7 +7,7 @@ export const metrics = new Metrics({
 
 export function createSingleMetric(
   name: string,
-  unit: MetricUnits,
+  unit: MetricUnit,
   value: number,
   dimensions: Record<string, string> = {},
 ): ReturnType<typeof metrics.singleMetric> {

--- a/lambdas/libs/aws-powertools-util/src/metrics/metrics.test.ts
+++ b/lambdas/libs/aws-powertools-util/src/metrics/metrics.test.ts
@@ -1,4 +1,4 @@
-import { MetricUnits, Metrics } from '@aws-lambda-powertools/metrics';
+import { MetricUnit, Metrics } from '@aws-lambda-powertools/metrics';
 import { createSingleMetric } from '../';
 
 process.env.POWERTOOLS_METRICS_NAMESPACE = 'test';
@@ -10,13 +10,13 @@ describe('A root tracer.', () => {
 
   it('should create a single metric without dimensions', () => {
     const spy = jest.spyOn(Metrics.prototype, 'singleMetric');
-    createSingleMetric('test', MetricUnits.Count, 1);
+    createSingleMetric('test', MetricUnit.Count, 1);
     expect(spy).toHaveBeenCalled();
   });
 
   test('should create a single metric', () => {
     const spy = jest.spyOn(Metrics.prototype, 'singleMetric');
-    createSingleMetric('test', MetricUnits.Count, 1, { test: 'test' });
+    createSingleMetric('test', MetricUnit.Count, 1, { test: 'test' });
     expect(spy).toHaveBeenCalled();
   });
 });

--- a/lambdas/libs/aws-powertools-util/src/tracer/index.ts
+++ b/lambdas/libs/aws-powertools-util/src/tracer/index.ts
@@ -1,4 +1,5 @@
-import { Tracer, captureLambdaHandler } from '@aws-lambda-powertools/tracer';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import { captureLambdaHandler } from '@aws-lambda-powertools/tracer/middleware';
 
 const tracer = new Tracer();
 

--- a/lambdas/yarn.lock
+++ b/lambdas/yarn.lock
@@ -97,54 +97,54 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-lambda-powertools/commons@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "@aws-lambda-powertools/commons@npm:1.18.1"
-  checksum: 10c0/5c5b748b03f166cf3efce99e3e5029cb4615d2e31b0593586479f0101b61de34f35ad380ea058fc3ba4c11444c0701daad2f833405db79ee6a69979bfaf14d50
+"@aws-lambda-powertools/commons@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "@aws-lambda-powertools/commons@npm:2.6.0"
+  checksum: 10c0/e236e5d02b66b824916bb7626008ebf4e884b517afb4ef79caea58e58bbb61455e17f5b95522c21784372de2912d05c7cc69001d9009bad3057f6ec7cf005aab
   languageName: node
   linkType: hard
 
-"@aws-lambda-powertools/logger@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "@aws-lambda-powertools/logger@npm:1.18.1"
+"@aws-lambda-powertools/logger@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "@aws-lambda-powertools/logger@npm:2.6.0"
   dependencies:
-    "@aws-lambda-powertools/commons": "npm:^1.18.1"
+    "@aws-lambda-powertools/commons": "npm:^2.6.0"
     lodash.merge: "npm:^4.6.2"
   peerDependencies:
-    "@middy/core": ">=3.x"
+    "@middy/core": 4.x || 5.x
   peerDependenciesMeta:
     "@middy/core":
       optional: true
-  checksum: 10c0/3d9c43bd2d68b47bd4eb0e96268382bd2b40e6009c8faf4072ff8e673fddd25a2f113a65f6fd319839680478f03c34abe3cca1acf4b76e101807e587cad61dfc
+  checksum: 10c0/b6f89363d8f635fd8429f156e02c9eb0e8f2cfbe37cc774075262666e9a67f91af84a5a28fcb34197616e3fb85f62243746381a61b3a638169401307f18e84e6
   languageName: node
   linkType: hard
 
-"@aws-lambda-powertools/metrics@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "@aws-lambda-powertools/metrics@npm:1.18.1"
+"@aws-lambda-powertools/metrics@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "@aws-lambda-powertools/metrics@npm:2.6.0"
   dependencies:
-    "@aws-lambda-powertools/commons": "npm:^1.18.1"
+    "@aws-lambda-powertools/commons": "npm:^2.6.0"
   peerDependencies:
-    "@middy/core": ">=3.x"
+    "@middy/core": 4.x || 5.x
   peerDependenciesMeta:
     "@middy/core":
       optional: true
-  checksum: 10c0/1e4bacc5069140ff84ceca2d27b104b0d6ee862eccd8bd8180e18459ae2bc6d753649d1b5d4579fdfd26ac74f6406a37be2d8ce662150795beb2ffd6063799da
+  checksum: 10c0/270913878d7e6703c47414fa22af15463814cd971eeeb32fc673d1e24f72dce950e5879f10c190286d7ea8dbe82d5de82b901bf49faf3bc1da5e2c6f52ca124e
   languageName: node
   linkType: hard
 
-"@aws-lambda-powertools/tracer@npm:^1.18.1":
-  version: 1.18.1
-  resolution: "@aws-lambda-powertools/tracer@npm:1.18.1"
+"@aws-lambda-powertools/tracer@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "@aws-lambda-powertools/tracer@npm:2.6.0"
   dependencies:
-    "@aws-lambda-powertools/commons": "npm:^1.18.1"
-    aws-xray-sdk-core: "npm:^3.5.3"
+    "@aws-lambda-powertools/commons": "npm:^2.6.0"
+    aws-xray-sdk-core: "npm:^3.9.0"
   peerDependencies:
-    "@middy/core": ">=3.x"
+    "@middy/core": 4.x || 5.x
   peerDependenciesMeta:
     "@middy/core":
       optional: true
-  checksum: 10c0/3b2932608f93cb5ceb2ceb9a0d861b26f231d9739e9869748515cbea30b31d7ecb388c7915cff7b74ac9a2649360024b930b3697d530a0b5e19b5383b080f79b
+  checksum: 10c0/e3e5c2fa47a9784c4e99f5e72498756d30895215237bf9fa4b24db98522510144710264b317bd01c2f8bba52b631d9bc6de00347b4ea5e47f9f8e328debbb616
   languageName: node
   linkType: hard
 
@@ -4630,9 +4630,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@terraform-aws-github-runner/aws-powertools-util@workspace:libs/aws-powertools-util"
   dependencies:
-    "@aws-lambda-powertools/logger": "npm:^1.18.1"
-    "@aws-lambda-powertools/metrics": "npm:^1.18.1"
-    "@aws-lambda-powertools/tracer": "npm:^1.18.1"
+    "@aws-lambda-powertools/logger": "npm:^2.6.0"
+    "@aws-lambda-powertools/metrics": "npm:^2.6.0"
+    "@aws-lambda-powertools/tracer": "npm:^2.6.0"
     "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
     "@types/aws-lambda": "npm:^8.10.142"
     "@types/express": "npm:^4.17.21"
@@ -5634,7 +5634,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-xray-sdk-core@npm:^3.5.3":
+"aws-xray-sdk-core@npm:^3.9.0":
   version: 3.9.0
   resolution: "aws-xray-sdk-core@npm:3.9.0"
   dependencies:


### PR DESCRIPTION
## Problem
AWS powetertools v1 will be end of life on Sept 1st 2024. Secondly upgrade to v2 is required to move to ESM

See https://docs.powertools.aws.dev/lambda/typescript/latest/upgrade/