### PR TITLE
docs: Remove outdated instruction from contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,6 @@ Before you submit your pull request consider the following guidelines:
         terraform init
         ```
 
-* For updating docs, you have to enable GitHub actions on your forked repository. Simply go to the tab Actions and enable actions.
 * Commit your changes using a descriptive commit message:
 
     ```shell


### PR DESCRIPTION
The process of updating the Terraform module documentation is now run on the `main` branch ([example](https://github.com/philips-labs/terraform-aws-github-runner/pull/3919)), so it no longer needs to be run on forked repositories (it also requires credentials for the GitHub App).

As per @npalm's [comment](https://github.com/philips-labs/terraform-aws-github-runner/pull/4063#issuecomment-2286734539), I'm removing this reference, to prevent any confusion for new contributors.