### PR TITLE
fix: missing lambda s3 key and version for job retry

### DIFF
--- a/modules/runners/job-retry.tf
+++ b/modules/runners/job-retry.tf
@@ -19,6 +19,8 @@ locals {
     role_path                   = var.role_path
     role_permissions_boundary   = var.role_permissions_boundary
     s3_bucket                   = var.lambda_s3_bucket
+    s3_key                      = var.runners_lambda_s3_key
+    s3_object_version           = var.runners_lambda_s3_object_version
     tracing_config              = var.tracing_config
     github_app_parameters       = var.github_app_parameters
     enable_organization_runners = var.enable_organization_runners


### PR DESCRIPTION
# Problem
Object key and object version not passed into job retry module.