### PR TITLE
fix: use name instead of name prefix to avoid too long names

### DIFF
--- a/modules/runners/pool/main.tf
+++ b/modules/runners/pool/main.tf
@@ -199,8 +199,8 @@ resource "aws_iam_role" "scheduler" {
 resource "aws_scheduler_schedule" "pool" {
   for_each = { for i, v in var.config.pool : i => v }
 
-  name_prefix = "${var.config.prefix}-pool-${each.key}-rule"
-  group_name  = aws_scheduler_schedule_group.pool.name
+  name       = "${var.config.prefix}-pool-${each.key}-rule"
+  group_name = aws_scheduler_schedule_group.pool.name
 
   flexible_time_window {
     mode = "OFF"


### PR DESCRIPTION
## Problme
In #4063 PR the EventBridge Schedule is introduces. For schedule groups a name prefix is used. But since the name for the name prefix is already unieque the name can be used instead of prefix to avoid too long prefix names (30 chars plus).
