### PR TITLE
fix: add missing prefix to ami cleanur for event rule

### DIFF
--- a/modules/ami-housekeeper/main.tf
+++ b/modules/ami-housekeeper/main.tf
@@ -100,7 +100,7 @@ resource "aws_iam_role_policy" "ami_housekeeper" {
 }
 
 resource "aws_cloudwatch_event_rule" "ami_housekeeper" {
-  name                = "ami-housekeeper-rule"
+  name                = "${var.prefix}-ami-housekeeper"
   schedule_expression = var.lambda_schedule_expression
   tags                = var.tags
   state               = var.state_event_rule_ami_housekeeper


### PR DESCRIPTION
## Problem

Created even rule for ami is static, it missing a dynamic element (prefix) to ensure unique resources.