### PR TITLE
fix: job retry resource and queue naming

### DIFF
--- a/modules/runners/README.md
+++ b/modules/runners/README.md
@@ -88,6 +88,7 @@ yarn run dist
 | [aws_iam_role_policy.describe_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.dist_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.job_retry_sqs_publish](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.runner_session_manager_aws_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.scale_down](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.scale_down_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
@@ -100,7 +101,6 @@ yarn run dist
 | [aws_iam_role_policy.ssm_housekeeper_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ssm_housekeeper_xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ssm_parameters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.webhook_workflow_job_sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.ami_id_ssm_parameter_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.managed_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.scale_down_vpc_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/modules/runners/job-retry/main.tf
+++ b/modules/runners/job-retry/main.tf
@@ -26,7 +26,7 @@ resource "aws_sqs_queue_policy" "job_retry_check_queue_policy" {
 }
 
 resource "aws_sqs_queue" "job_retry_check_queue" {
-  name                       = "${var.config.prefix}-job-retrys"
+  name                       = "${var.config.prefix}-job-retry"
   visibility_timeout_seconds = local.config.timeout
 
   sqs_managed_sse_enabled           = var.config.queue_encryption.sqs_managed_sse_enabled

--- a/modules/runners/scale-up.tf
+++ b/modules/runners/scale-up.tf
@@ -153,7 +153,7 @@ resource "aws_iam_role_policy" "scale_up_xray" {
   role   = aws_iam_role.scale_up.name
 }
 
-resource "aws_iam_role_policy" "webhook_workflow_job_sqs" {
+resource "aws_iam_role_policy" "job_retry_sqs_publish" {
   count = local.job_retry_enabled ? 1 : 0
   name  = "publish-retry-check-sqs-policy"
   role  = aws_iam_role.scale_up.name


### PR DESCRIPTION
## Fixes
- resource incorrect named (copy / paste)
- typo in queue name for rety