### PR TITLE
chore: replace npm private package scope by an org we own

### DIFF
--- a/lambdas/functions/ami-housekeeper/package.json
+++ b/lambdas/functions/ami-housekeeper/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@terraform-aws-github-runner/ami-housekeeper",
+  "name": "@aws-github-runner/ami-housekeeper",
   "version": "1.0.0",
   "main": "lambda.ts",
   "license": "MIT",
@@ -37,11 +37,11 @@
     "ts-node-dev": "^2.0.0"
   },
   "dependencies": {
+    "@aws-github-runner/aws-powertools-util": "*",
+    "@aws-github-runner/aws-ssm-util": "*",
     "@aws-sdk/client-ec2": "^3.637.0",
     "@aws-sdk/client-ssm": "^3.637.0",
     "@aws-sdk/types": "^3.609.0",
-    "@terraform-aws-github-runner/aws-powertools-util": "*",
-    "@terraform-aws-github-runner/aws-ssm-util": "*",
     "cron-parser": "^4.9.0",
     "typescript": "^5.5.4"
   },

--- a/lambdas/functions/ami-housekeeper/src/ami.ts
+++ b/lambdas/functions/ami-housekeeper/src/ami.ts
@@ -9,8 +9,8 @@ import {
   Image,
 } from '@aws-sdk/client-ec2';
 import { DescribeParametersCommand, GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
-import { createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
-import { getTracedAWSV3Client } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
+import { getTracedAWSV3Client } from '@aws-github-runner/aws-powertools-util';
 
 const logger = createChildLogger('ami');
 

--- a/lambdas/functions/ami-housekeeper/src/lambda.test.ts
+++ b/lambdas/functions/ami-housekeeper/src/lambda.test.ts
@@ -1,4 +1,4 @@
-import { logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger } from '@aws-github-runner/aws-powertools-util';
 import { Context } from 'aws-lambda';
 import { mocked } from 'jest-mock';
 
@@ -6,7 +6,7 @@ import { AmiCleanupOptions, amiCleanup } from './ami';
 import { handler } from './lambda';
 
 jest.mock('./ami');
-jest.mock('@terraform-aws-github-runner/aws-powertools-util');
+jest.mock('@aws-github-runner/aws-powertools-util');
 
 const amiCleanupOptions: AmiCleanupOptions = {
   minimumDaysOld: undefined,

--- a/lambdas/functions/ami-housekeeper/src/lambda.ts
+++ b/lambdas/functions/ami-housekeeper/src/lambda.ts
@@ -1,4 +1,4 @@
-import { logger, setContext } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger, setContext } from '@aws-github-runner/aws-powertools-util';
 import { Context } from 'aws-lambda';
 import 'source-map-support/register';
 

--- a/lambdas/functions/ami-housekeeper/src/local.ts
+++ b/lambdas/functions/ami-housekeeper/src/local.ts
@@ -1,4 +1,4 @@
-import { logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger } from '@aws-github-runner/aws-powertools-util';
 
 import { amiCleanup } from './ami';
 

--- a/lambdas/functions/control-plane/package.json
+++ b/lambdas/functions/control-plane/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@terraform-aws-github-runner/control-plane",
+  "name": "@aws-github-runner/control-plane",
   "version": "1.0.0",
   "main": "lambda.ts",
   "license": "MIT",
@@ -38,6 +38,8 @@
     "ts-node-dev": "^2.0.0"
   },
   "dependencies": {
+    "@aws-github-runner/aws-powertools-util": "*",
+    "@aws-github-runner/aws-ssm-util": "*",
     "@aws-lambda-powertools/parameters": "^2.7.0",
     "@aws-sdk/client-ec2": "^3.637.0",
     "@aws-sdk/client-sqs": "^3.637.0",
@@ -48,8 +50,6 @@
     "@octokit/plugin-throttling": "8.2.0",
     "@octokit/rest": "20.1.1",
     "@octokit/types": "^13.5.0",
-    "@terraform-aws-github-runner/aws-powertools-util": "*",
-    "@terraform-aws-github-runner/aws-ssm-util": "*",
     "cron-parser": "^4.9.0",
     "typescript": "^5.5.4"
   },

--- a/lambdas/functions/control-plane/src/aws/runners.test.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.test.ts
@@ -12,7 +12,7 @@ import {
   TerminateInstancesCommand,
 } from '@aws-sdk/client-ec2';
 import { GetParameterCommand, GetParameterResult, PutParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
-import { tracer } from '@terraform-aws-github-runner/aws-powertools-util';
+import { tracer } from '@aws-github-runner/aws-powertools-util';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 

--- a/lambdas/functions/control-plane/src/aws/runners.ts
+++ b/lambdas/functions/control-plane/src/aws/runners.ts
@@ -10,9 +10,9 @@ import {
   TerminateInstancesCommand,
   _InstanceType,
 } from '@aws-sdk/client-ec2';
-import { createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
-import { getTracedAWSV3Client, tracer } from '@terraform-aws-github-runner/aws-powertools-util';
-import { getParameter } from '@terraform-aws-github-runner/aws-ssm-util';
+import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
+import { getTracedAWSV3Client, tracer } from '@aws-github-runner/aws-powertools-util';
+import { getParameter } from '@aws-github-runner/aws-ssm-util';
 import moment from 'moment';
 
 import ScaleError from './../scale-runners/ScaleError';

--- a/lambdas/functions/control-plane/src/aws/sqs.test.ts
+++ b/lambdas/functions/control-plane/src/aws/sqs.test.ts
@@ -2,7 +2,7 @@ import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import { publishMessage } from './sqs';
-import { logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger } from '@aws-github-runner/aws-powertools-util';
 
 const mockSQSClient = mockClient(SQSClient);
 

--- a/lambdas/functions/control-plane/src/aws/sqs.ts
+++ b/lambdas/functions/control-plane/src/aws/sqs.ts
@@ -1,5 +1,5 @@
 import { SQSClient, SendMessageCommand, SendMessageCommandOutput } from '@aws-sdk/client-sqs';
-import { logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger } from '@aws-github-runner/aws-powertools-util';
 
 const sqs = new SQSClient({});
 

--- a/lambdas/functions/control-plane/src/github/auth.test.ts
+++ b/lambdas/functions/control-plane/src/github/auth.test.ts
@@ -2,14 +2,14 @@ import { createAppAuth } from '@octokit/auth-app';
 import { StrategyOptions } from '@octokit/auth-app/dist-types/types';
 import { request } from '@octokit/request';
 import { RequestInterface } from '@octokit/types';
-import { getParameter } from '@terraform-aws-github-runner/aws-ssm-util';
+import { getParameter } from '@aws-github-runner/aws-ssm-util';
 import { mocked } from 'jest-mock';
 import { MockProxy, mock } from 'jest-mock-extended';
 import nock from 'nock';
 
 import { createGithubAppAuth, createOctokitClient } from './auth';
 
-jest.mock('@terraform-aws-github-runner/aws-ssm-util');
+jest.mock('@aws-github-runner/aws-ssm-util');
 jest.mock('@octokit/auth-app');
 
 const cleanEnv = process.env;

--- a/lambdas/functions/control-plane/src/github/auth.ts
+++ b/lambdas/functions/control-plane/src/github/auth.ts
@@ -11,8 +11,8 @@ import { OctokitOptions } from '@octokit/core/dist-types/types';
 import { request } from '@octokit/request';
 import { Octokit } from '@octokit/rest';
 import { throttling } from '@octokit/plugin-throttling';
-import { createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
-import { getParameter } from '@terraform-aws-github-runner/aws-ssm-util';
+import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
+import { getParameter } from '@aws-github-runner/aws-ssm-util';
 import { EndpointDefaults } from '@octokit/types';
 
 const logger = createChildLogger('gh-auth');

--- a/lambdas/functions/control-plane/src/github/rate-limit.test.ts
+++ b/lambdas/functions/control-plane/src/github/rate-limit.test.ts
@@ -1,11 +1,11 @@
 import { ResponseHeaders } from '@octokit/types';
-import { createSingleMetric } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createSingleMetric } from '@aws-github-runner/aws-powertools-util';
 import { MetricUnit } from '@aws-lambda-powertools/metrics';
 import { metricGitHubAppRateLimit } from './rate-limit';
 
 process.env.PARAMETER_GITHUB_APP_ID_NAME = 'test';
-jest.mock('@terraform-aws-github-runner/aws-ssm-util', () => ({
-  ...jest.requireActual('@terraform-aws-github-runner/aws-ssm-util'),
+jest.mock('@aws-github-runner/aws-ssm-util', () => ({
+  ...jest.requireActual('@aws-github-runner/aws-ssm-util'),
   // get parameter name from process.env.PARAMETER_GITHUB_APP_ID_NAME rerunt 1234
   getParameter: jest.fn((name: string) => {
     if (name === process.env.PARAMETER_GITHUB_APP_ID_NAME) {
@@ -16,8 +16,8 @@ jest.mock('@terraform-aws-github-runner/aws-ssm-util', () => ({
   }),
 }));
 
-jest.mock('@terraform-aws-github-runner/aws-powertools-util', () => ({
-  ...jest.requireActual('@terraform-aws-github-runner/aws-powertools-util'),
+jest.mock('@aws-github-runner/aws-powertools-util', () => ({
+  ...jest.requireActual('@aws-github-runner/aws-powertools-util'),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   createSingleMetric: jest.fn((name: string, unit: string, value: number, dimensions?: Record<string, string>) => {
     return {

--- a/lambdas/functions/control-plane/src/github/rate-limit.ts
+++ b/lambdas/functions/control-plane/src/github/rate-limit.ts
@@ -1,8 +1,8 @@
 import { ResponseHeaders } from '@octokit/types';
-import { createSingleMetric, logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createSingleMetric, logger } from '@aws-github-runner/aws-powertools-util';
 import { MetricUnit } from '@aws-lambda-powertools/metrics';
 import yn from 'yn';
-import { getParameter } from '@terraform-aws-github-runner/aws-ssm-util';
+import { getParameter } from '@aws-github-runner/aws-ssm-util';
 
 export async function metricGitHubAppRateLimit(headers: ResponseHeaders): Promise<void> {
   try {

--- a/lambdas/functions/control-plane/src/lambda.test.ts
+++ b/lambdas/functions/control-plane/src/lambda.test.ts
@@ -1,4 +1,4 @@
-import { captureLambdaHandler, logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { captureLambdaHandler, logger } from '@aws-github-runner/aws-powertools-util';
 import { Context, SQSEvent, SQSRecord } from 'aws-lambda';
 import { mocked } from 'jest-mock';
 
@@ -66,8 +66,8 @@ jest.mock('./scale-runners/scale-down');
 jest.mock('./scale-runners/scale-up');
 jest.mock('./scale-runners/ssm-housekeeper');
 jest.mock('./scale-runners/job-retry');
-jest.mock('@terraform-aws-github-runner/aws-powertools-util');
-jest.mock('@terraform-aws-github-runner/aws-ssm-util');
+jest.mock('@aws-github-runner/aws-powertools-util');
+jest.mock('@aws-github-runner/aws-ssm-util');
 
 // Docs for testing async with jest: https://jestjs.io/docs/tutorial-async
 describe('Test scale up lambda wrapper.', () => {

--- a/lambdas/functions/control-plane/src/lambda.ts
+++ b/lambdas/functions/control-plane/src/lambda.ts
@@ -1,6 +1,6 @@
 import middy from '@middy/core';
-import { logger, setContext } from '@terraform-aws-github-runner/aws-powertools-util';
-import { captureLambdaHandler, tracer } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger, setContext } from '@aws-github-runner/aws-powertools-util';
+import { captureLambdaHandler, tracer } from '@aws-github-runner/aws-powertools-util';
 import { Context, SQSEvent } from 'aws-lambda';
 
 import { PoolEvent, adjust } from './pool/pool';

--- a/lambdas/functions/control-plane/src/local.ts
+++ b/lambdas/functions/control-plane/src/local.ts
@@ -1,4 +1,4 @@
-import { logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger } from '@aws-github-runner/aws-powertools-util';
 
 import { ActionRequestMessage, scaleUp } from './scale-runners/scale-up';
 

--- a/lambdas/functions/control-plane/src/pool/pool.ts
+++ b/lambdas/functions/control-plane/src/pool/pool.ts
@@ -1,5 +1,5 @@
 import { Octokit } from '@octokit/rest';
-import { createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import yn from 'yn';
 
 import { bootTimeExceeded, listEC2Runners } from '../aws/runners';

--- a/lambdas/functions/control-plane/src/scale-runners/job-retry.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/job-retry.test.ts
@@ -4,12 +4,12 @@ import { ActionRequestMessage, ActionRequestMessageRetry } from './scale-up';
 import { getOctokit } from '../github/octokit';
 import { Octokit } from '@octokit/rest';
 import { mocked } from 'jest-mock';
-import { createSingleMetric } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createSingleMetric } from '@aws-github-runner/aws-powertools-util';
 
 jest.mock('../aws/sqs');
 
-jest.mock('@terraform-aws-github-runner/aws-powertools-util', () => ({
-  ...jest.requireActual('@terraform-aws-github-runner/aws-powertools-util'),
+jest.mock('@aws-github-runner/aws-powertools-util', () => ({
+  ...jest.requireActual('@aws-github-runner/aws-powertools-util'),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   createSingleMetric: jest.fn((name: string, unit: string, value: number, dimensions?: Record<string, string>) => {
     return {

--- a/lambdas/functions/control-plane/src/scale-runners/job-retry.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/job-retry.ts
@@ -1,8 +1,4 @@
-import {
-  addPersistentContextToChildLogger,
-  createSingleMetric,
-  logger,
-} from '@aws-github-runner/aws-powertools-util';
+import { addPersistentContextToChildLogger, createSingleMetric, logger } from '@aws-github-runner/aws-powertools-util';
 import { publishMessage } from '../aws/sqs';
 import { ActionRequestMessage, ActionRequestMessageRetry, getGitHubEnterpriseApiUrl, isJobQueued } from './scale-up';
 import { getOctokit } from '../github/octokit';

--- a/lambdas/functions/control-plane/src/scale-runners/job-retry.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/job-retry.ts
@@ -2,7 +2,7 @@ import {
   addPersistentContextToChildLogger,
   createSingleMetric,
   logger,
-} from '@terraform-aws-github-runner/aws-powertools-util';
+} from '@aws-github-runner/aws-powertools-util';
 import { publishMessage } from '../aws/sqs';
 import { ActionRequestMessage, ActionRequestMessageRetry, getGitHubEnterpriseApiUrl, isJobQueued } from './scale-up';
 import { getOctokit } from '../github/octokit';

--- a/lambdas/functions/control-plane/src/scale-runners/scale-down-config.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down-config.ts
@@ -1,4 +1,4 @@
-import { createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import parser from 'cron-parser';
 import moment from 'moment';
 

--- a/lambdas/functions/control-plane/src/scale-runners/scale-down.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-down.ts
@@ -1,5 +1,5 @@
 import { Octokit } from '@octokit/rest';
-import { createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import moment from 'moment';
 
 import { createGithubAppAuth, createGithubInstallationAuth, createOctokitClient } from '../github/auth';

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.test.ts
@@ -11,7 +11,7 @@ import { createRunner, listEC2Runners } from './../aws/runners';
 import { RunnerInputParameters } from './../aws/runners.d';
 import ScaleError from './ScaleError';
 import * as scaleUpModule from './scale-up';
-import { getParameter } from '@terraform-aws-github-runner/aws-ssm-util';
+import { getParameter } from '@aws-github-runner/aws-ssm-util';
 
 const mockOctokit = {
   paginate: jest.fn(),
@@ -40,8 +40,8 @@ jest.mock('@octokit/rest', () => ({
 jest.mock('./../aws/runners');
 jest.mock('./../github/auth');
 
-jest.mock('@terraform-aws-github-runner/aws-ssm-util', () => ({
-  ...jest.requireActual('@terraform-aws-github-runner/aws-ssm-util'),
+jest.mock('@aws-github-runner/aws-ssm-util', () => ({
+  ...jest.requireActual('@aws-github-runner/aws-ssm-util'),
   getParameter: jest.fn(),
 }));
 

--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -1,6 +1,6 @@
 import { Octokit } from '@octokit/rest';
-import { addPersistentContextToChildLogger, createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
-import { getParameter, putParameter } from '@terraform-aws-github-runner/aws-ssm-util';
+import { addPersistentContextToChildLogger, createChildLogger } from '@aws-github-runner/aws-powertools-util';
+import { getParameter, putParameter } from '@aws-github-runner/aws-ssm-util';
 import yn from 'yn';
 
 import { createGithubAppAuth, createGithubInstallationAuth, createOctokitClient } from '../github/auth';

--- a/lambdas/functions/control-plane/src/scale-runners/ssm-housekeeper.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/ssm-housekeeper.ts
@@ -1,6 +1,6 @@
 import { DeleteParameterCommand, GetParametersByPathCommand, SSMClient } from '@aws-sdk/client-ssm';
-import { logger } from '@terraform-aws-github-runner/aws-powertools-util';
-import { getTracedAWSV3Client } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger } from '@aws-github-runner/aws-powertools-util';
+import { getTracedAWSV3Client } from '@aws-github-runner/aws-powertools-util';
 
 export interface SSMCleanupOptions {
   dryRun: boolean;

--- a/lambdas/functions/gh-agent-syncer/package.json
+++ b/lambdas/functions/gh-agent-syncer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@terraform-aws-github-runner/gh-agent-syncer",
+  "name": "@aws-github-runner/gh-agent-syncer",
   "version": "1.0.0",
   "main": "lambda.ts",
   "license": "MIT",
@@ -36,12 +36,12 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
+    "@aws-github-runner/aws-powertools-util": "*",
     "@aws-sdk/client-s3": "^3.637.0",
     "@aws-sdk/lib-storage": "^3.637.0",
     "@aws-sdk/types": "^3.609.0",
     "@middy/core": "^4.7.0",
     "@octokit/rest": "20.1.1",
-    "@terraform-aws-github-runner/aws-powertools-util": "*",
     "axios": "^1.7.5"
   },
   "nx": {

--- a/lambdas/functions/gh-agent-syncer/src/lambda.ts
+++ b/lambdas/functions/gh-agent-syncer/src/lambda.ts
@@ -1,6 +1,6 @@
 import middy from '@middy/core';
-import { logger, setContext } from '@terraform-aws-github-runner/aws-powertools-util';
-import { captureLambdaHandler, tracer } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger, setContext } from '@aws-github-runner/aws-powertools-util';
+import { captureLambdaHandler, tracer } from '@aws-github-runner/aws-powertools-util';
 import { Context } from 'aws-lambda';
 
 import { sync } from './syncer/syncer';

--- a/lambdas/functions/gh-agent-syncer/src/local.ts
+++ b/lambdas/functions/gh-agent-syncer/src/local.ts
@@ -1,4 +1,4 @@
-import { logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger } from '@aws-github-runner/aws-powertools-util';
 
 import { sync } from './syncer/syncer';
 

--- a/lambdas/functions/gh-agent-syncer/src/syncer/syncer.ts
+++ b/lambdas/functions/gh-agent-syncer/src/syncer/syncer.ts
@@ -1,8 +1,8 @@
 import { GetObjectTaggingCommand, S3Client, ServerSideEncryption, Tag } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { Octokit } from '@octokit/rest';
-import { createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
-import { getTracedAWSV3Client } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
+import { getTracedAWSV3Client } from '@aws-github-runner/aws-powertools-util';
 import axios from 'axios';
 import { Stream } from 'stream';
 

--- a/lambdas/functions/termination-watcher/package.json
+++ b/lambdas/functions/termination-watcher/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@terraform-aws-github-runner/termination-watcher",
+  "name": "@aws-github-runner/termination-watcher",
   "version": "1.0.0",
   "main": "lambda.ts",
   "license": "MIT",
@@ -35,10 +35,10 @@
     "ts-node-dev": "^2.0.0"
   },
   "dependencies": {
+    "@aws-github-runner/aws-powertools-util": "*",
     "@aws-sdk/client-ec2": "^3.637.0",
     "@aws-sdk/types": "^3.609.0",
     "@middy/core": "^4.7.0",
-    "@terraform-aws-github-runner/aws-powertools-util": "*",
     "typescript": "^5.5.4"
   },
   "nx": {

--- a/lambdas/functions/termination-watcher/src/ConfigResolver.ts
+++ b/lambdas/functions/termination-watcher/src/ConfigResolver.ts
@@ -1,4 +1,4 @@
-import { createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 
 export class Config {
   createSpotWarningMetric: boolean;

--- a/lambdas/functions/termination-watcher/src/lambda.test.ts
+++ b/lambdas/functions/termination-watcher/src/lambda.test.ts
@@ -1,4 +1,4 @@
-import { logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger } from '@aws-github-runner/aws-powertools-util';
 import { Context } from 'aws-lambda';
 import { mocked } from 'jest-mock';
 

--- a/lambdas/functions/termination-watcher/src/lambda.ts
+++ b/lambdas/functions/termination-watcher/src/lambda.ts
@@ -5,7 +5,7 @@ import {
   metrics,
   setContext,
   tracer,
-} from '@terraform-aws-github-runner/aws-powertools-util';
+} from '@aws-github-runner/aws-powertools-util';
 import { logMetrics } from '@aws-lambda-powertools/metrics/middleware';
 import { Context } from 'aws-lambda';
 

--- a/lambdas/functions/termination-watcher/src/lambda.ts
+++ b/lambdas/functions/termination-watcher/src/lambda.ts
@@ -1,11 +1,5 @@
 import middy from '@middy/core';
-import {
-  captureLambdaHandler,
-  logger,
-  metrics,
-  setContext,
-  tracer,
-} from '@aws-github-runner/aws-powertools-util';
+import { captureLambdaHandler, logger, metrics, setContext, tracer } from '@aws-github-runner/aws-powertools-util';
 import { logMetrics } from '@aws-lambda-powertools/metrics/middleware';
 import { Context } from 'aws-lambda';
 

--- a/lambdas/functions/termination-watcher/src/termination-warning.test.ts
+++ b/lambdas/functions/termination-watcher/src/termination-warning.test.ts
@@ -3,11 +3,11 @@ import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import { handle } from './termination-warning';
 import { SpotInterruptionWarning, SpotTerminationDetail } from './types';
-import { createSingleMetric } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createSingleMetric } from '@aws-github-runner/aws-powertools-util';
 import { MetricUnit } from '@aws-lambda-powertools/metrics';
 
-jest.mock('@terraform-aws-github-runner/aws-powertools-util', () => ({
-  ...jest.requireActual('@terraform-aws-github-runner/aws-powertools-util'),
+jest.mock('@aws-github-runner/aws-powertools-util', () => ({
+  ...jest.requireActual('@aws-github-runner/aws-powertools-util'),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   createSingleMetric: jest.fn((name: string, unit: string, value: number, dimensions?: Record<string, string>) => {
     return {

--- a/lambdas/functions/termination-watcher/src/termination-warning.ts
+++ b/lambdas/functions/termination-watcher/src/termination-warning.ts
@@ -2,7 +2,7 @@ import {
   createChildLogger,
   createSingleMetric,
   getTracedAWSV3Client,
-} from '@terraform-aws-github-runner/aws-powertools-util';
+} from '@aws-github-runner/aws-powertools-util';
 import { SpotInterruptionWarning, SpotTerminationDetail } from './types';
 import { DescribeInstancesCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { Config } from './ConfigResolver';

--- a/lambdas/functions/termination-watcher/src/termination-warning.ts
+++ b/lambdas/functions/termination-watcher/src/termination-warning.ts
@@ -1,8 +1,4 @@
-import {
-  createChildLogger,
-  createSingleMetric,
-  getTracedAWSV3Client,
-} from '@aws-github-runner/aws-powertools-util';
+import { createChildLogger, createSingleMetric, getTracedAWSV3Client } from '@aws-github-runner/aws-powertools-util';
 import { SpotInterruptionWarning, SpotTerminationDetail } from './types';
 import { DescribeInstancesCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { Config } from './ConfigResolver';

--- a/lambdas/functions/webhook/package.json
+++ b/lambdas/functions/webhook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@terraform-aws-github-runner/webhook",
+  "name": "@aws-github-runner/webhook",
   "version": "1.0.0",
   "main": "lambda.ts",
   "license": "MIT",
@@ -37,13 +37,13 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
+    "@aws-github-runner/aws-powertools-util": "*",
+    "@aws-github-runner/aws-ssm-util": "*",
     "@aws-sdk/client-sqs": "^3.637.0",
     "@middy/core": "^4.7.0",
     "@octokit/rest": "20.1.1",
     "@octokit/types": "^13.5.0",
     "@octokit/webhooks": "^12.2.0",
-    "@terraform-aws-github-runner/aws-powertools-util": "*",
-    "@terraform-aws-github-runner/aws-ssm-util": "*",
     "aws-lambda": "^1.0.7"
   },
   "nx": {

--- a/lambdas/functions/webhook/src/ConfigResolver.ts
+++ b/lambdas/functions/webhook/src/ConfigResolver.ts
@@ -1,6 +1,6 @@
-import { getParameter } from '@terraform-aws-github-runner/aws-ssm-util';
+import { getParameter } from '@aws-github-runner/aws-ssm-util';
 import { RunnerMatcherConfig } from './sqs';
-import { logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger } from '@aws-github-runner/aws-powertools-util';
 
 export class Config {
   repositoryAllowList: Array<string>;

--- a/lambdas/functions/webhook/src/lambda.test.ts
+++ b/lambdas/functions/webhook/src/lambda.test.ts
@@ -1,11 +1,11 @@
-import { logger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger } from '@aws-github-runner/aws-powertools-util';
 import { APIGatewayEvent, Context } from 'aws-lambda';
 import { mocked } from 'jest-mock';
 
 import { githubWebhook } from './lambda';
 import { handle } from './webhook';
 import ValidationError from './ValidatonError';
-import { getParameter } from '@terraform-aws-github-runner/aws-ssm-util';
+import { getParameter } from '@aws-github-runner/aws-ssm-util';
 
 const event: APIGatewayEvent = {
   body: JSON.stringify(''),
@@ -74,7 +74,7 @@ const context: Context = {
 };
 
 jest.mock('./webhook');
-jest.mock('@terraform-aws-github-runner/aws-ssm-util');
+jest.mock('@aws-github-runner/aws-ssm-util');
 
 describe('Test scale up lambda wrapper.', () => {
   beforeEach(() => {

--- a/lambdas/functions/webhook/src/lambda.ts
+++ b/lambdas/functions/webhook/src/lambda.ts
@@ -1,5 +1,5 @@
 import middy from '@middy/core';
-import { logger, setContext, captureLambdaHandler, tracer } from '@terraform-aws-github-runner/aws-powertools-util';
+import { logger, setContext, captureLambdaHandler, tracer } from '@aws-github-runner/aws-powertools-util';
 import { APIGatewayEvent, Context } from 'aws-lambda';
 
 import { handle } from './webhook';

--- a/lambdas/functions/webhook/src/sqs/index.test.ts
+++ b/lambdas/functions/webhook/src/sqs/index.test.ts
@@ -3,7 +3,7 @@ import { SendMessageCommandInput } from '@aws-sdk/client-sqs';
 import { ActionRequestMessage, GithubWorkflowEvent, sendActionRequest, sendWebhookEventToWorkflowJobQueue } from '.';
 import workflowjob_event from '../../test/resources/github_workflowjob_event.json';
 import { Config } from '../ConfigResolver';
-import { getParameter } from '@terraform-aws-github-runner/aws-ssm-util';
+import { getParameter } from '@aws-github-runner/aws-ssm-util';
 import { mocked } from 'jest-mock';
 
 const mockSQS = {
@@ -14,7 +14,7 @@ const mockSQS = {
 jest.mock('@aws-sdk/client-sqs', () => ({
   SQS: jest.fn().mockImplementation(() => mockSQS),
 }));
-jest.mock('@terraform-aws-github-runner/aws-ssm-util');
+jest.mock('@aws-github-runner/aws-ssm-util');
 
 import { SQS } from '@aws-sdk/client-sqs';
 

--- a/lambdas/functions/webhook/src/sqs/index.ts
+++ b/lambdas/functions/webhook/src/sqs/index.ts
@@ -1,6 +1,6 @@
 import { SQS, SendMessageCommandInput } from '@aws-sdk/client-sqs';
 import { WorkflowJobEvent } from '@octokit/webhooks-types';
-import { createChildLogger, getTracedAWSV3Client } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createChildLogger, getTracedAWSV3Client } from '@aws-github-runner/aws-powertools-util';
 import { Config } from '../ConfigResolver';
 
 const logger = createChildLogger('sqs');

--- a/lambdas/functions/webhook/src/webhook/index.test.ts
+++ b/lambdas/functions/webhook/src/webhook/index.test.ts
@@ -1,5 +1,5 @@
 import { Webhooks } from '@octokit/webhooks';
-import { getParameter } from '@terraform-aws-github-runner/aws-ssm-util';
+import { getParameter } from '@aws-github-runner/aws-ssm-util';
 import { mocked } from 'jest-mock';
 import nock from 'nock';
 
@@ -12,7 +12,7 @@ import { canRunJob, handle } from '.';
 import { Config } from '../ConfigResolver';
 
 jest.mock('../sqs');
-jest.mock('@terraform-aws-github-runner/aws-ssm-util');
+jest.mock('@aws-github-runner/aws-ssm-util');
 
 const GITHUB_APP_WEBHOOK_SECRET = 'TEST_SECRET';
 

--- a/lambdas/functions/webhook/src/webhook/index.ts
+++ b/lambdas/functions/webhook/src/webhook/index.ts
@@ -1,6 +1,6 @@
 import { Webhooks } from '@octokit/webhooks';
 import { CheckRunEvent, WorkflowJobEvent } from '@octokit/webhooks-types';
-import { createChildLogger } from '@terraform-aws-github-runner/aws-powertools-util';
+import { createChildLogger } from '@aws-github-runner/aws-powertools-util';
 import { IncomingHttpHeaders } from 'http';
 
 import { Response } from '../lambda';

--- a/lambdas/libs/aws-powertools-util/package.json
+++ b/lambdas/libs/aws-powertools-util/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@terraform-aws-github-runner/aws-powertools-util",
+  "name": "@aws-github-runner/aws-powertools-util",
   "version": "1.0.0",
   "main": "src/index.ts",
   "license": "MIT",

--- a/lambdas/libs/aws-ssm-util/package.json
+++ b/lambdas/libs/aws-ssm-util/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@terraform-aws-github-runner/aws-ssm-util",
+  "name": "@aws-github-runner/aws-ssm-util",
   "version": "1.0.0",
   "main": "src/index.ts",
   "license": "MIT",
@@ -35,9 +35,9 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
+    "@aws-github-runner/aws-powertools-util": "*",
     "@aws-sdk/client-ssm": "^3.637.0",
-    "@aws-sdk/types": "^3.609.0",
-    "@terraform-aws-github-runner/aws-powertools-util": "*"
+    "@aws-sdk/types": "^3.609.0"
   },
   "nx": {
     "includedScripts": [

--- a/lambdas/libs/aws-ssm-util/src/index.ts
+++ b/lambdas/libs/aws-ssm-util/src/index.ts
@@ -1,5 +1,5 @@
 import { PutParameterCommand, SSMClient, Tag } from '@aws-sdk/client-ssm';
-import { getTracedAWSV3Client } from '@terraform-aws-github-runner/aws-powertools-util';
+import { getTracedAWSV3Client } from '@aws-github-runner/aws-powertools-util';
 import { SSMProvider } from '@aws-lambda-powertools/parameters/ssm';
 
 export async function getParameter(parameter_name: string): Promise<string> {

--- a/lambdas/yarn.lock
+++ b/lambdas/yarn.lock
@@ -97,6 +97,236 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-github-runner/ami-housekeeper@workspace:functions/ami-housekeeper":
+  version: 0.0.0-use.local
+  resolution: "@aws-github-runner/ami-housekeeper@workspace:functions/ami-housekeeper"
+  dependencies:
+    "@aws-github-runner/aws-powertools-util": "npm:*"
+    "@aws-github-runner/aws-ssm-util": "npm:*"
+    "@aws-sdk/client-ec2": "npm:^3.637.0"
+    "@aws-sdk/client-ssm": "npm:^3.637.0"
+    "@aws-sdk/types": "npm:^3.609.0"
+    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
+    "@types/aws-lambda": "npm:^8.10.143"
+    "@types/jest": "npm:^29.5.12"
+    "@types/node": "npm:^22.4.1"
+    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
+    "@typescript-eslint/parser": "npm:^7.18.0"
+    "@vercel/ncc": "npm:^0.38.1"
+    aws-sdk-client-mock: "npm:^4.0.1"
+    aws-sdk-client-mock-jest: "npm:^4.0.1"
+    cron-parser: "npm:^4.9.0"
+    eslint: "npm:^8.57.0"
+    eslint-plugin-prettier: "npm:5.2.1"
+    jest: "npm:^29.7.0"
+    jest-mock: "npm:^29.7.0"
+    jest-mock-extended: "npm:^3.0.7"
+    nock: "npm:^13.5.4"
+    prettier: "npm:3.3.3"
+    ts-jest: "npm:^29.2.5"
+    ts-node: "npm:^10.9.2"
+    ts-node-dev: "npm:^2.0.0"
+    typescript: "npm:^5.5.4"
+  languageName: unknown
+  linkType: soft
+
+"@aws-github-runner/aws-powertools-util@npm:*, @aws-github-runner/aws-powertools-util@workspace:libs/aws-powertools-util":
+  version: 0.0.0-use.local
+  resolution: "@aws-github-runner/aws-powertools-util@workspace:libs/aws-powertools-util"
+  dependencies:
+    "@aws-lambda-powertools/logger": "npm:^2.7.0"
+    "@aws-lambda-powertools/metrics": "npm:^2.7.0"
+    "@aws-lambda-powertools/tracer": "npm:^2.7.0"
+    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
+    "@types/aws-lambda": "npm:^8.10.143"
+    "@types/express": "npm:^4.17.21"
+    "@types/jest": "npm:^29.5.12"
+    "@types/node": "npm:^22.4.1"
+    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
+    "@typescript-eslint/parser": "npm:^7.18.0"
+    "@vercel/ncc": "npm:0.38.1"
+    aws-lambda: "npm:^1.0.7"
+    body-parser: "npm:^1.20.2"
+    eslint: "npm:^8.57.0"
+    eslint-plugin-prettier: "npm:5.2.1"
+    express: "npm:^4.19.2"
+    jest: "npm:^29.7.0"
+    jest-mock: "npm:^29.7.0"
+    nock: "npm:^13.5.4"
+    prettier: "npm:3.3.3"
+    ts-jest: "npm:^29.2.5"
+    ts-node-dev: "npm:^2.0.0"
+    typescript: "npm:^5.5.4"
+  languageName: unknown
+  linkType: soft
+
+"@aws-github-runner/aws-ssm-util@npm:*, @aws-github-runner/aws-ssm-util@workspace:libs/aws-ssm-util":
+  version: 0.0.0-use.local
+  resolution: "@aws-github-runner/aws-ssm-util@workspace:libs/aws-ssm-util"
+  dependencies:
+    "@aws-github-runner/aws-powertools-util": "npm:*"
+    "@aws-sdk/client-ssm": "npm:^3.637.0"
+    "@aws-sdk/types": "npm:^3.609.0"
+    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
+    "@types/aws-lambda": "npm:^8.10.143"
+    "@types/express": "npm:^4.17.21"
+    "@types/jest": "npm:^29.5.12"
+    "@types/node": "npm:^22.4.1"
+    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
+    "@typescript-eslint/parser": "npm:^7.18.0"
+    "@vercel/ncc": "npm:0.38.1"
+    body-parser: "npm:^1.20.2"
+    eslint: "npm:^8.57.0"
+    eslint-plugin-prettier: "npm:5.2.1"
+    express: "npm:^4.19.2"
+    jest: "npm:^29.7.0"
+    jest-mock: "npm:^29.7.0"
+    nock: "npm:^13.5.4"
+    prettier: "npm:3.3.3"
+    ts-jest: "npm:^29.2.5"
+    ts-node-dev: "npm:^2.0.0"
+    typescript: "npm:^5.5.4"
+  languageName: unknown
+  linkType: soft
+
+"@aws-github-runner/control-plane@workspace:functions/control-plane":
+  version: 0.0.0-use.local
+  resolution: "@aws-github-runner/control-plane@workspace:functions/control-plane"
+  dependencies:
+    "@aws-github-runner/aws-powertools-util": "npm:*"
+    "@aws-github-runner/aws-ssm-util": "npm:*"
+    "@aws-lambda-powertools/parameters": "npm:^2.7.0"
+    "@aws-sdk/client-ec2": "npm:^3.637.0"
+    "@aws-sdk/client-sqs": "npm:^3.637.0"
+    "@aws-sdk/types": "npm:^3.609.0"
+    "@middy/core": "npm:^4.7.0"
+    "@octokit/auth-app": "npm:6.1.1"
+    "@octokit/core": "npm:5.2.0"
+    "@octokit/plugin-throttling": "npm:8.2.0"
+    "@octokit/rest": "npm:20.1.1"
+    "@octokit/types": "npm:^13.5.0"
+    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
+    "@types/aws-lambda": "npm:^8.10.143"
+    "@types/jest": "npm:^29.5.12"
+    "@types/node": "npm:^22.4.1"
+    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
+    "@typescript-eslint/parser": "npm:^7.18.0"
+    "@vercel/ncc": "npm:^0.38.1"
+    aws-sdk-client-mock: "npm:^4.0.1"
+    aws-sdk-client-mock-jest: "npm:^4.0.1"
+    cron-parser: "npm:^4.9.0"
+    eslint: "npm:^8.57.0"
+    eslint-plugin-prettier: "npm:5.2.1"
+    jest: "npm:^29.7.0"
+    jest-mock: "npm:^29.7.0"
+    jest-mock-extended: "npm:^3.0.7"
+    moment-timezone: "npm:^0.5.45"
+    nock: "npm:^13.5.4"
+    prettier: "npm:3.3.3"
+    ts-jest: "npm:^29.2.5"
+    ts-node: "npm:^10.9.2"
+    ts-node-dev: "npm:^2.0.0"
+    typescript: "npm:^5.5.4"
+  languageName: unknown
+  linkType: soft
+
+"@aws-github-runner/gh-agent-syncer@workspace:functions/gh-agent-syncer":
+  version: 0.0.0-use.local
+  resolution: "@aws-github-runner/gh-agent-syncer@workspace:functions/gh-agent-syncer"
+  dependencies:
+    "@aws-github-runner/aws-powertools-util": "npm:*"
+    "@aws-sdk/client-s3": "npm:^3.637.0"
+    "@aws-sdk/lib-storage": "npm:^3.637.0"
+    "@aws-sdk/types": "npm:^3.609.0"
+    "@middy/core": "npm:^4.7.0"
+    "@octokit/rest": "npm:20.1.1"
+    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
+    "@types/aws-lambda": "npm:^8.10.143"
+    "@types/jest": "npm:^29.5.12"
+    "@types/node": "npm:^22.4.1"
+    "@types/request": "npm:^2.48.12"
+    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
+    "@typescript-eslint/parser": "npm:^7.18.0"
+    "@vercel/ncc": "npm:^0.38.1"
+    aws-sdk-client-mock: "npm:^4.0.1"
+    aws-sdk-client-mock-jest: "npm:^4.0.1"
+    axios: "npm:^1.7.5"
+    eslint: "npm:^8.57.0"
+    eslint-plugin-prettier: "npm:5.2.1"
+    jest: "npm:^29.7.0"
+    jest-mock: "npm:^29.7.0"
+    prettier: "npm:3.3.3"
+    ts-jest: "npm:^29.2.5"
+    ts-node-dev: "npm:^2.0.0"
+    typescript: "npm:^5.5.4"
+  languageName: unknown
+  linkType: soft
+
+"@aws-github-runner/termination-watcher@workspace:functions/termination-watcher":
+  version: 0.0.0-use.local
+  resolution: "@aws-github-runner/termination-watcher@workspace:functions/termination-watcher"
+  dependencies:
+    "@aws-github-runner/aws-powertools-util": "npm:*"
+    "@aws-sdk/client-ec2": "npm:^3.637.0"
+    "@aws-sdk/types": "npm:^3.609.0"
+    "@middy/core": "npm:^4.7.0"
+    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
+    "@types/aws-lambda": "npm:^8.10.143"
+    "@types/jest": "npm:^29.5.12"
+    "@types/node": "npm:^22.4.1"
+    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
+    "@typescript-eslint/parser": "npm:^7.18.0"
+    "@vercel/ncc": "npm:^0.38.1"
+    aws-sdk-client-mock: "npm:^4.0.1"
+    aws-sdk-client-mock-jest: "npm:^4.0.1"
+    eslint: "npm:^8.57.0"
+    eslint-plugin-prettier: "npm:5.2.1"
+    jest: "npm:^29.7.0"
+    jest-mock: "npm:^29.7.0"
+    jest-mock-extended: "npm:^3.0.7"
+    nock: "npm:^13.5.4"
+    prettier: "npm:3.3.3"
+    ts-jest: "npm:^29.2.5"
+    ts-node: "npm:^10.9.2"
+    ts-node-dev: "npm:^2.0.0"
+    typescript: "npm:^5.5.4"
+  languageName: unknown
+  linkType: soft
+
+"@aws-github-runner/webhook@workspace:functions/webhook":
+  version: 0.0.0-use.local
+  resolution: "@aws-github-runner/webhook@workspace:functions/webhook"
+  dependencies:
+    "@aws-github-runner/aws-powertools-util": "npm:*"
+    "@aws-github-runner/aws-ssm-util": "npm:*"
+    "@aws-sdk/client-sqs": "npm:^3.637.0"
+    "@middy/core": "npm:^4.7.0"
+    "@octokit/rest": "npm:20.1.1"
+    "@octokit/types": "npm:^13.5.0"
+    "@octokit/webhooks": "npm:^12.2.0"
+    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
+    "@types/aws-lambda": "npm:^8.10.143"
+    "@types/express": "npm:^4.17.21"
+    "@types/jest": "npm:^29.5.12"
+    "@types/node": "npm:^22.4.1"
+    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
+    "@typescript-eslint/parser": "npm:^7.18.0"
+    "@vercel/ncc": "npm:0.38.1"
+    aws-lambda: "npm:^1.0.7"
+    body-parser: "npm:^1.20.2"
+    eslint: "npm:^8.57.0"
+    eslint-plugin-prettier: "npm:5.2.1"
+    express: "npm:^4.19.2"
+    jest: "npm:^29.7.0"
+    jest-mock: "npm:^29.7.0"
+    nock: "npm:^13.5.4"
+    prettier: "npm:3.3.3"
+    ts-jest: "npm:^29.2.5"
+    ts-node-dev: "npm:^2.0.0"
+    typescript: "npm:^5.5.4"
+  languageName: unknown
+  linkType: soft
+
 "@aws-lambda-powertools/commons@npm:^2.7.0":
   version: 2.7.0
   resolution: "@aws-lambda-powertools/commons@npm:2.7.0"
@@ -4747,236 +4977,6 @@ __metadata:
   checksum: 10c0/f95fea7dee8fc07f8389afbb9578f3d0cd84b429b1d0dbff7fd99b2ef06ed88e96bc33631f36c3bc0505d5a783bee1374acd84b8fc2593001219b6c2caba241b
   languageName: node
   linkType: hard
-
-"@terraform-aws-github-runner/ami-housekeeper@workspace:functions/ami-housekeeper":
-  version: 0.0.0-use.local
-  resolution: "@terraform-aws-github-runner/ami-housekeeper@workspace:functions/ami-housekeeper"
-  dependencies:
-    "@aws-sdk/client-ec2": "npm:^3.637.0"
-    "@aws-sdk/client-ssm": "npm:^3.637.0"
-    "@aws-sdk/types": "npm:^3.609.0"
-    "@terraform-aws-github-runner/aws-powertools-util": "npm:*"
-    "@terraform-aws-github-runner/aws-ssm-util": "npm:*"
-    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
-    "@types/aws-lambda": "npm:^8.10.143"
-    "@types/jest": "npm:^29.5.12"
-    "@types/node": "npm:^22.4.1"
-    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
-    "@typescript-eslint/parser": "npm:^7.18.0"
-    "@vercel/ncc": "npm:^0.38.1"
-    aws-sdk-client-mock: "npm:^4.0.1"
-    aws-sdk-client-mock-jest: "npm:^4.0.1"
-    cron-parser: "npm:^4.9.0"
-    eslint: "npm:^8.57.0"
-    eslint-plugin-prettier: "npm:5.2.1"
-    jest: "npm:^29.7.0"
-    jest-mock: "npm:^29.7.0"
-    jest-mock-extended: "npm:^3.0.7"
-    nock: "npm:^13.5.4"
-    prettier: "npm:3.3.3"
-    ts-jest: "npm:^29.2.5"
-    ts-node: "npm:^10.9.2"
-    ts-node-dev: "npm:^2.0.0"
-    typescript: "npm:^5.5.4"
-  languageName: unknown
-  linkType: soft
-
-"@terraform-aws-github-runner/aws-powertools-util@npm:*, @terraform-aws-github-runner/aws-powertools-util@workspace:libs/aws-powertools-util":
-  version: 0.0.0-use.local
-  resolution: "@terraform-aws-github-runner/aws-powertools-util@workspace:libs/aws-powertools-util"
-  dependencies:
-    "@aws-lambda-powertools/logger": "npm:^2.7.0"
-    "@aws-lambda-powertools/metrics": "npm:^2.7.0"
-    "@aws-lambda-powertools/tracer": "npm:^2.7.0"
-    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
-    "@types/aws-lambda": "npm:^8.10.143"
-    "@types/express": "npm:^4.17.21"
-    "@types/jest": "npm:^29.5.12"
-    "@types/node": "npm:^22.4.1"
-    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
-    "@typescript-eslint/parser": "npm:^7.18.0"
-    "@vercel/ncc": "npm:0.38.1"
-    aws-lambda: "npm:^1.0.7"
-    body-parser: "npm:^1.20.2"
-    eslint: "npm:^8.57.0"
-    eslint-plugin-prettier: "npm:5.2.1"
-    express: "npm:^4.19.2"
-    jest: "npm:^29.7.0"
-    jest-mock: "npm:^29.7.0"
-    nock: "npm:^13.5.4"
-    prettier: "npm:3.3.3"
-    ts-jest: "npm:^29.2.5"
-    ts-node-dev: "npm:^2.0.0"
-    typescript: "npm:^5.5.4"
-  languageName: unknown
-  linkType: soft
-
-"@terraform-aws-github-runner/aws-ssm-util@npm:*, @terraform-aws-github-runner/aws-ssm-util@workspace:libs/aws-ssm-util":
-  version: 0.0.0-use.local
-  resolution: "@terraform-aws-github-runner/aws-ssm-util@workspace:libs/aws-ssm-util"
-  dependencies:
-    "@aws-sdk/client-ssm": "npm:^3.637.0"
-    "@aws-sdk/types": "npm:^3.609.0"
-    "@terraform-aws-github-runner/aws-powertools-util": "npm:*"
-    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
-    "@types/aws-lambda": "npm:^8.10.143"
-    "@types/express": "npm:^4.17.21"
-    "@types/jest": "npm:^29.5.12"
-    "@types/node": "npm:^22.4.1"
-    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
-    "@typescript-eslint/parser": "npm:^7.18.0"
-    "@vercel/ncc": "npm:0.38.1"
-    body-parser: "npm:^1.20.2"
-    eslint: "npm:^8.57.0"
-    eslint-plugin-prettier: "npm:5.2.1"
-    express: "npm:^4.19.2"
-    jest: "npm:^29.7.0"
-    jest-mock: "npm:^29.7.0"
-    nock: "npm:^13.5.4"
-    prettier: "npm:3.3.3"
-    ts-jest: "npm:^29.2.5"
-    ts-node-dev: "npm:^2.0.0"
-    typescript: "npm:^5.5.4"
-  languageName: unknown
-  linkType: soft
-
-"@terraform-aws-github-runner/control-plane@workspace:functions/control-plane":
-  version: 0.0.0-use.local
-  resolution: "@terraform-aws-github-runner/control-plane@workspace:functions/control-plane"
-  dependencies:
-    "@aws-lambda-powertools/parameters": "npm:^2.7.0"
-    "@aws-sdk/client-ec2": "npm:^3.637.0"
-    "@aws-sdk/client-sqs": "npm:^3.637.0"
-    "@aws-sdk/types": "npm:^3.609.0"
-    "@middy/core": "npm:^4.7.0"
-    "@octokit/auth-app": "npm:6.1.1"
-    "@octokit/core": "npm:5.2.0"
-    "@octokit/plugin-throttling": "npm:8.2.0"
-    "@octokit/rest": "npm:20.1.1"
-    "@octokit/types": "npm:^13.5.0"
-    "@terraform-aws-github-runner/aws-powertools-util": "npm:*"
-    "@terraform-aws-github-runner/aws-ssm-util": "npm:*"
-    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
-    "@types/aws-lambda": "npm:^8.10.143"
-    "@types/jest": "npm:^29.5.12"
-    "@types/node": "npm:^22.4.1"
-    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
-    "@typescript-eslint/parser": "npm:^7.18.0"
-    "@vercel/ncc": "npm:^0.38.1"
-    aws-sdk-client-mock: "npm:^4.0.1"
-    aws-sdk-client-mock-jest: "npm:^4.0.1"
-    cron-parser: "npm:^4.9.0"
-    eslint: "npm:^8.57.0"
-    eslint-plugin-prettier: "npm:5.2.1"
-    jest: "npm:^29.7.0"
-    jest-mock: "npm:^29.7.0"
-    jest-mock-extended: "npm:^3.0.7"
-    moment-timezone: "npm:^0.5.45"
-    nock: "npm:^13.5.4"
-    prettier: "npm:3.3.3"
-    ts-jest: "npm:^29.2.5"
-    ts-node: "npm:^10.9.2"
-    ts-node-dev: "npm:^2.0.0"
-    typescript: "npm:^5.5.4"
-  languageName: unknown
-  linkType: soft
-
-"@terraform-aws-github-runner/gh-agent-syncer@workspace:functions/gh-agent-syncer":
-  version: 0.0.0-use.local
-  resolution: "@terraform-aws-github-runner/gh-agent-syncer@workspace:functions/gh-agent-syncer"
-  dependencies:
-    "@aws-sdk/client-s3": "npm:^3.637.0"
-    "@aws-sdk/lib-storage": "npm:^3.637.0"
-    "@aws-sdk/types": "npm:^3.609.0"
-    "@middy/core": "npm:^4.7.0"
-    "@octokit/rest": "npm:20.1.1"
-    "@terraform-aws-github-runner/aws-powertools-util": "npm:*"
-    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
-    "@types/aws-lambda": "npm:^8.10.143"
-    "@types/jest": "npm:^29.5.12"
-    "@types/node": "npm:^22.4.1"
-    "@types/request": "npm:^2.48.12"
-    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
-    "@typescript-eslint/parser": "npm:^7.18.0"
-    "@vercel/ncc": "npm:^0.38.1"
-    aws-sdk-client-mock: "npm:^4.0.1"
-    aws-sdk-client-mock-jest: "npm:^4.0.1"
-    axios: "npm:^1.7.5"
-    eslint: "npm:^8.57.0"
-    eslint-plugin-prettier: "npm:5.2.1"
-    jest: "npm:^29.7.0"
-    jest-mock: "npm:^29.7.0"
-    prettier: "npm:3.3.3"
-    ts-jest: "npm:^29.2.5"
-    ts-node-dev: "npm:^2.0.0"
-    typescript: "npm:^5.5.4"
-  languageName: unknown
-  linkType: soft
-
-"@terraform-aws-github-runner/termination-watcher@workspace:functions/termination-watcher":
-  version: 0.0.0-use.local
-  resolution: "@terraform-aws-github-runner/termination-watcher@workspace:functions/termination-watcher"
-  dependencies:
-    "@aws-sdk/client-ec2": "npm:^3.637.0"
-    "@aws-sdk/types": "npm:^3.609.0"
-    "@middy/core": "npm:^4.7.0"
-    "@terraform-aws-github-runner/aws-powertools-util": "npm:*"
-    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
-    "@types/aws-lambda": "npm:^8.10.143"
-    "@types/jest": "npm:^29.5.12"
-    "@types/node": "npm:^22.4.1"
-    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
-    "@typescript-eslint/parser": "npm:^7.18.0"
-    "@vercel/ncc": "npm:^0.38.1"
-    aws-sdk-client-mock: "npm:^4.0.1"
-    aws-sdk-client-mock-jest: "npm:^4.0.1"
-    eslint: "npm:^8.57.0"
-    eslint-plugin-prettier: "npm:5.2.1"
-    jest: "npm:^29.7.0"
-    jest-mock: "npm:^29.7.0"
-    jest-mock-extended: "npm:^3.0.7"
-    nock: "npm:^13.5.4"
-    prettier: "npm:3.3.3"
-    ts-jest: "npm:^29.2.5"
-    ts-node: "npm:^10.9.2"
-    ts-node-dev: "npm:^2.0.0"
-    typescript: "npm:^5.5.4"
-  languageName: unknown
-  linkType: soft
-
-"@terraform-aws-github-runner/webhook@workspace:functions/webhook":
-  version: 0.0.0-use.local
-  resolution: "@terraform-aws-github-runner/webhook@workspace:functions/webhook"
-  dependencies:
-    "@aws-sdk/client-sqs": "npm:^3.637.0"
-    "@middy/core": "npm:^4.7.0"
-    "@octokit/rest": "npm:20.1.1"
-    "@octokit/types": "npm:^13.5.0"
-    "@octokit/webhooks": "npm:^12.2.0"
-    "@terraform-aws-github-runner/aws-powertools-util": "npm:*"
-    "@terraform-aws-github-runner/aws-ssm-util": "npm:*"
-    "@trivago/prettier-plugin-sort-imports": "npm:^4.3.0"
-    "@types/aws-lambda": "npm:^8.10.143"
-    "@types/express": "npm:^4.17.21"
-    "@types/jest": "npm:^29.5.12"
-    "@types/node": "npm:^22.4.1"
-    "@typescript-eslint/eslint-plugin": "npm:^7.18.0"
-    "@typescript-eslint/parser": "npm:^7.18.0"
-    "@vercel/ncc": "npm:0.38.1"
-    aws-lambda: "npm:^1.0.7"
-    body-parser: "npm:^1.20.2"
-    eslint: "npm:^8.57.0"
-    eslint-plugin-prettier: "npm:5.2.1"
-    express: "npm:^4.19.2"
-    jest: "npm:^29.7.0"
-    jest-mock: "npm:^29.7.0"
-    nock: "npm:^13.5.4"
-    prettier: "npm:3.3.3"
-    ts-jest: "npm:^29.2.5"
-    ts-node-dev: "npm:^2.0.0"
-    typescript: "npm:^5.5.4"
-  languageName: unknown
-  linkType: soft
 
 "@trivago/prettier-plugin-sort-imports@npm:^4.3.0":
   version: 4.3.0


### PR DESCRIPTION
## Description

This change replaces the scope of the scope by an [org](https://www.npmjs.com/org/aws-github-runner) we own. Although packages are proper locked by scope and workspace this is only to make absolute sure we own the namespace.