### PR TITLE
docs: explicit naming submodules

### DIFF
--- a/docs/modules/runners.md
+++ b/docs/modules/runners.md
@@ -1,4 +1,4 @@
-# Runner module (main))
+# Runner module (main)
 
 !!! note
     This is the top-level module located in the root of the repository. The directory [`modules/runners`](../internal/runners/) contains an internal Terraform sub-module used by this and the [mult-runner module](../public/multi-runner/)

--- a/docs/modules/runners.md
+++ b/docs/modules/runners.md
@@ -1,5 +1,13 @@
-# Runner module (Top Level Directory)
+# Runner module (main))
+
+!!! note
+    This is the top-level module located in the root of the repository. The directory [`modules/runners`](../internal/runners/) contains an internal Terraform sub-module used by this and the [mult-runner module](../public/multi-runner/)
 
 This module creates resources in your AWS infrastructure, and EC2 instances for hosting the self-hosted runners on-demand. IAM permissions are set to a minimal level, and could be further limited by using permission boundaries. Instances permissions are limited to retrieve and delete the registration token, access the instance's own tags, and terminate the instance itself. By nature instances are short-lived, we strongly suggest to use ephemeral runners to ensure a safe build environment for each workflow job execution.
+
+Example usages:
+
+- [Basic example](../../examples/default/)
+- [Ephemeral example](../../examples/ephemeral/)
 
 --8<-- "README.md:mkdocsrunners"

--- a/docs/modules/runners.md
+++ b/docs/modules/runners.md
@@ -1,4 +1,4 @@
-# Runner module (root)
+# Runner module (Top Level Directory)
 
 This module creates resources in your AWS infrastructure, and EC2 instances for hosting the self-hosted runners on-demand. IAM permissions are set to a minimal level, and could be further limited by using permission boundaries. Instances permissions are limited to retrieve and delete the registration token, access the instance's own tags, and terminate the instance itself. By nature instances are short-lived, we strongly suggest to use ephemeral runners to ensure a safe build environment for each workflow job execution.
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -53,12 +53,13 @@ nav:
   - Getting started: getting-started.md
   - Security: security.md
   - Modules:
-    - Runners (root): modules/runners.md
-    - Multi Runners: modules/public/multi-runner.md
-    - AMI Housekeeper: modules/public/ami-housekeeper.md
-    - Lambda Downloader: modules/public/download-lambda.md
-    - Setup IAM permissions: modules/public/setup-iam-permissions.md
-    - Internal:
+    - Runners (main): modules/runners.md
+    - Submodules (public):
+      - Multi Runners: modules/public/multi-runner.md
+      - AMI Housekeeper: modules/public/ami-housekeeper.md
+      - Lambda Downloader: modules/public/download-lambda.md
+      - Setup IAM permissions: modules/public/setup-iam-permissions.md
+    - Submodules (internal):
       - Runners: modules/internal/runners.md
       - Syncer: modules/internal/runner-binaries-syncer.md
       - SSM: modules/internal/ssm.md


### PR DESCRIPTION
## Description

Make explicit what is the main and what is a submodule.

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/7f3876eb-8401-4bfe-a7b6-cf42f88dac5e">
