### PR TITLE
chore: fix null version to major

### DIFF
--- a/modules/download-lambda/README.md
+++ b/modules/download-lambda/README.md
@@ -31,7 +31,7 @@ module "lambdas" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.27 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3 |
 
 ## Providers
 

--- a/modules/download-lambda/versions.tf
+++ b/modules/download-lambda/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.0"
+      version = "~> 3"
     }
   }
 }

--- a/modules/webhook/README.md
+++ b/modules/webhook/README.md
@@ -37,14 +37,14 @@ yarn run dist
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.27 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.27 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3 |
 
 ## Modules
 

--- a/modules/webhook/versions.tf
+++ b/modules/webhook/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.2"
+      version = "~> 3"
     }
   }
 }


### PR DESCRIPTION
This PR removes the minor version lock for modules to align them with others.

Kudos to [rishta](https://github.com/rishta) for spotting this issue and trying to help us resolve it