### PR TITLE
fix(webhook): add missing permission to workflow job queue (EventBridge)

### DIFF
--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -26,6 +26,11 @@ module "runners" {
     Project = "ProjectX"
   }
 
+  eventbridge = {
+    enable = true
+  }
+  enable_workflow_job_events_queue = true
+
   github_app = {
     key_base64     = var.github_app.key_base64
     id             = var.github_app.id

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -26,11 +26,6 @@ module "runners" {
     Project = "ProjectX"
   }
 
-  eventbridge = {
-    enable = true
-  }
-  enable_workflow_job_events_queue = true
-
   github_app = {
     key_base64     = var.github_app.key_base64
     id             = var.github_app.id

--- a/modules/webhook/eventbridge/README.md
+++ b/modules/webhook/eventbridge/README.md
@@ -34,12 +34,12 @@ No modules.
 | [aws_iam_role_policy.dispatcher_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.dispatcher_sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.dispatcher_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.dispatcher_workflow_job_sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.dispatcher_xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.webhook_eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.webhook_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.webhook_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.webhook_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.webhook_workflow_job_sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.dispatcher_vpc_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.webhook_vpc_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/modules/webhook/eventbridge/README.md
+++ b/modules/webhook/eventbridge/README.md
@@ -39,6 +39,7 @@ No modules.
 | [aws_iam_role_policy.webhook_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.webhook_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.webhook_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.webhook_workflow_job_sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.dispatcher_vpc_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.webhook_vpc_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/modules/webhook/eventbridge/dispatcher.tf
+++ b/modules/webhook/eventbridge/dispatcher.tf
@@ -143,3 +143,13 @@ resource "aws_iam_role_policy" "dispatcher_xray" {
   policy = data.aws_iam_policy_document.lambda_xray[0].json
   role   = aws_iam_role.dispatcher_lambda.name
 }
+
+resource "aws_iam_role_policy" "webhook_workflow_job_sqs" {
+  count = var.config.sqs_workflow_job_queue != null ? 1 : 0
+  name  = "publish-workflow-job-sqs-policy"
+  role  = aws_iam_role.webhook_lambda.name
+
+  policy = templatefile("${path.module}/../policies/lambda-publish-sqs-policy.json", {
+    sqs_resource_arns = jsonencode([var.config.sqs_workflow_job_queue.arn])
+  })
+}

--- a/modules/webhook/eventbridge/dispatcher.tf
+++ b/modules/webhook/eventbridge/dispatcher.tf
@@ -144,10 +144,10 @@ resource "aws_iam_role_policy" "dispatcher_xray" {
   role   = aws_iam_role.dispatcher_lambda.name
 }
 
-resource "aws_iam_role_policy" "webhook_workflow_job_sqs" {
+resource "aws_iam_role_policy" "dispatcher_workflow_job_sqs" {
   count = var.config.sqs_workflow_job_queue != null ? 1 : 0
   name  = "publish-workflow-job-sqs-policy"
-  role  = aws_iam_role.webhook_lambda.name
+  role  = aws_iam_role.dispatcher_lambda.name
 
   policy = templatefile("${path.module}/../policies/lambda-publish-sqs-policy.json", {
     sqs_resource_arns = jsonencode([var.config.sqs_workflow_job_queue.arn])


### PR DESCRIPTION
Dispatcher for EventBridge does not have access to sqs queueu for publish workflow job event. 