### PR TITLE
fix: trigger cold start dispatcher after update SSM parameters

### DIFF
--- a/modules/webhook/direct/README.md
+++ b/modules/webhook/direct/README.md
@@ -34,7 +34,6 @@ No modules.
 | [aws_lambda_function.webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [null_resource.github_app_parameters](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.ssm_parameter_runner_matcher_config](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_iam_policy_document.lambda_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/modules/webhook/direct/main.tf
+++ b/modules/webhook/direct/main.tf
@@ -1,6 +1,0 @@
-
-resource "null_resource" "ssm_parameter_runner_matcher_config" {
-  triggers = {
-    version = var.config.ssm_parameter_runner_matcher_config.version
-  }
-}

--- a/modules/webhook/direct/webhook.tf
+++ b/modules/webhook/direct/webhook.tf
@@ -28,6 +28,7 @@ resource "aws_lambda_function" "webhook" {
         REPOSITORY_ALLOW_LIST                    = jsonencode(var.config.repository_white_list)
         SQS_WORKFLOW_JOB_QUEUE                   = try(var.config.sqs_workflow_job_queue.id, null)
         PARAMETER_RUNNER_MATCHER_CONFIG_PATH     = var.config.ssm_parameter_runner_matcher_config.name
+        PARAMETER_RUNNER_MATCHER_VERSION         = var.config.ssm_parameter_runner_matcher_config.version # enforce cold start after Changes in SSM parameter
       } : k => v if v != null
     }
   }
@@ -50,7 +51,7 @@ resource "aws_lambda_function" "webhook" {
   }
 
   lifecycle {
-    replace_triggered_by = [null_resource.ssm_parameter_runner_matcher_config, null_resource.github_app_parameters]
+    replace_triggered_by = [null_resource.github_app_parameters]
   }
 }
 
@@ -68,7 +69,7 @@ resource "aws_lambda_permission" "webhook" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = var.config.api_gw_source_arn
   lifecycle {
-    replace_triggered_by = [null_resource.ssm_parameter_runner_matcher_config, null_resource.github_app_parameters]
+    replace_triggered_by = [null_resource.github_app_parameters]
   }
 }
 

--- a/modules/webhook/eventbridge/README.md
+++ b/modules/webhook/eventbridge/README.md
@@ -25,7 +25,7 @@ No modules.
 | [aws_cloudwatch_event_archive.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_archive) | resource |
 | [aws_cloudwatch_event_bus.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_bus) | resource |
 | [aws_cloudwatch_event_rule.workflow_job](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.github_welcome](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.dispatcher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_log_group.dispatcher](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_role.dispatcher_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -48,7 +48,6 @@ No modules.
 | [aws_lambda_permission.allow_cloudwatch_to_call_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.webhook](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [null_resource.github_app_parameters](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.ssm_parameter_runner_matcher_config](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_iam_policy_document.lambda_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/modules/webhook/eventbridge/main.tf
+++ b/modules/webhook/eventbridge/main.tf
@@ -13,9 +13,3 @@ resource "aws_cloudwatch_event_archive" "main" {
   event_source_arn = aws_cloudwatch_event_bus.main.arn
   retention_days   = var.config.archive.retention_days
 }
-
-resource "null_resource" "ssm_parameter_runner_matcher_config" {
-  triggers = {
-    version = var.config.ssm_parameter_runner_matcher_config.version
-  }
-}

--- a/modules/webhook/eventbridge/webhook.tf
+++ b/modules/webhook/eventbridge/webhook.tf
@@ -1,3 +1,9 @@
+resource "null_resource" "github_app_parameters" {
+  triggers = {
+    github_app_webhook_secret_name = var.config.github_app_parameters.webhook_secret.name
+  }
+}
+
 resource "aws_lambda_function" "webhook" {
   s3_bucket         = var.config.lambda_s3_bucket != null ? var.config.lambda_s3_bucket : null
   s3_key            = var.config.lambda_s3_key != null ? var.config.lambda_s3_key : null
@@ -48,7 +54,7 @@ resource "aws_lambda_function" "webhook" {
   }
 
   lifecycle {
-    replace_triggered_by = [null_resource.ssm_parameter_runner_matcher_config, null_resource.github_app_parameters]
+    replace_triggered_by = [null_resource.github_app_parameters]
   }
 }
 
@@ -65,14 +71,9 @@ resource "aws_lambda_permission" "webhook" {
   function_name = aws_lambda_function.webhook.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = var.config.api_gw_source_arn
-  lifecycle {
-    replace_triggered_by = [null_resource.ssm_parameter_runner_matcher_config, null_resource.github_app_parameters]
-  }
-}
 
-resource "null_resource" "github_app_parameters" {
-  triggers = {
-    github_app_webhook_secret = var.config.github_app_parameters.webhook_secret.name
+  lifecycle {
+    replace_triggered_by = [null_resource.github_app_parameters]
   }
 }
 


### PR DESCRIPTION
## Description

Currently we use the lifecyle trigger in Terraform to enforce lambda reload. Unwanted side-effect is resources getting destroyed. Even leading to the lambda trigger for the dispatch functiong not getting re-created.

Instead of adding the lifecyle event to multiple resources, the version of the SSM paramater is added to environment variables of the Lambda to enforce [cold start](https://docs.aws.amazon.com/lambda/latest/operatorguide/execution-environments.html) after updates. 

## Tested
- default example
- multi runner, changing labels