### PR TITLE
fix: dispatch only queued events to runners

### DIFF
--- a/modules/webhook/eventbridge/dispatcher.tf
+++ b/modules/webhook/eventbridge/dispatcher.tf
@@ -5,9 +5,10 @@ resource "aws_cloudwatch_event_rule" "workflow_job" {
 
   event_pattern = <<EOF
 {
-  "detail-type": [
-    "workflow_job"
-  ]
+  "detail-type": ["workflow_job"],
+  "detail": {
+    "action": ["queued"]
+  }
 }
 EOF
 }


### PR DESCRIPTION
## Description

Update dispatch to only subscribe for queued events instead for all events. 