### PR TITLE
chore: add nx group, and fix broken nx on mac

### DIFF
--- a/lambdas/package.json
+++ b/lambdas/package.json
@@ -22,14 +22,14 @@
   },
   "devDependencies": {
     "@nx/eslint": "20.0.8",
-    "@nx/jest": "20.1.2",
-    "@nx/js": "^20.1.2",
+    "@nx/jest": "20.0.1",
+    "@nx/js": "^20.0.1",
     "@swc-node/register": "~1.10.9",
     "@swc/core": "~1.7.40",
     "@swc/helpers": "~0.5.15",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
-    "nx": "20.1.2",
+    "nx": "20.0.1",
     "prettier": "^3.3.3",
     "typescript": "^5.6.3"
   },

--- a/lambdas/yarn.lock
+++ b/lambdas/yarn.lock
@@ -1192,23 +1192,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/types@npm:3.692.0, @aws-sdk/types@npm:^3.692.0":
+"@aws-sdk/types@npm:3.692.0, @aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.4.1, @aws-sdk/types@npm:^3.692.0":
   version: 3.692.0
   resolution: "@aws-sdk/types@npm:3.692.0"
   dependencies:
     "@smithy/types": "npm:^3.7.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/dc25a188dd8646a09eb08229a7fa957550f22fae64f11908e44df96d3e41192b666a500d6e55487b8e47fa926569dd3494cc6dcdd22512e4aa827f23650b93e1
-  languageName: node
-  linkType: hard
-
-"@aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.4.1":
-  version: 3.667.0
-  resolution: "@aws-sdk/types@npm:3.667.0"
-  dependencies:
-    "@smithy/types": "npm:^3.5.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/c1173d4799e95f113eeb80505737d86a37b443e45fac52d1045683712078ea338678bf9b55403254615f68e1ee8176084b9647c60e286c6a3569198611ffb9f5
   languageName: node
   linkType: hard
 
@@ -4544,15 +4534,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/types@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@smithy/types@npm:3.5.0"
-  dependencies:
-    tslib: "npm:^2.6.2"
-  checksum: 10c0/298f1638b0ba3a5cef3d238219cebab21f9479e54a5de3f7dbde5f65f7a3966a9623d4bb4e3856ef67bc6139a065a149379f6374e68bef380e8bb789c592db22
-  languageName: node
-  linkType: hard
-
 "@smithy/types@npm:^3.7.0, @smithy/types@npm:^3.7.1":
   version: 3.7.1
   resolution: "@smithy/types@npm:3.7.1"
@@ -5165,16 +5146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 22.5.4
-  resolution: "@types/node@npm:22.5.4"
-  dependencies:
-    undici-types: "npm:~6.19.2"
-  checksum: 10c0/b445daa7eecd761ad4d778b882d6ff7bcc3b4baad2086ea9804db7c5d4a4ab0298b00d7f5315fc640a73b5a1d52bbf9628e09c9fec0cf44dbf9b4df674a8717d
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^22.9.0":
+"@types/node@npm:*, @types/node@npm:^22.9.0":
   version: 22.9.0
   resolution: "@types/node@npm:22.9.0"
   dependencies:
@@ -11077,14 +11049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3":
-  version: 2.6.3
-  resolution: "tslib@npm:2.6.3"
-  checksum: 10c0/2598aef53d9dbe711af75522464b2104724d6467b26a60f2bdac8297d2b5f1f6b86a71f61717384aa8fd897240467aaa7bcc36a0700a0faf751293d1331db39a
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.8.0":
+"tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3, tslib@npm:^2.8.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -11171,7 +11136,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.19.2, undici-types@npm:~6.19.8":
+"undici-types@npm:~6.19.8":
   version: 6.19.8
   resolution: "undici-types@npm:6.19.8"
   checksum: 10c0/078afa5990fba110f6824823ace86073b4638f1d5112ee26e790155f481f2a868cc3e0615505b6f4282bdf74a3d8caad715fd809e870c2bb0704e3ea6082f344

--- a/lambdas/yarn.lock
+++ b/lambdas/yarn.lock
@@ -3241,6 +3241,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nx/devkit@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/devkit@npm:20.0.1"
+  dependencies:
+    ejs: "npm:^3.1.7"
+    enquirer: "npm:~2.3.6"
+    ignore: "npm:^5.0.4"
+    minimatch: "npm:9.0.3"
+    semver: "npm:^7.5.3"
+    tmp: "npm:~0.2.1"
+    tslib: "npm:^2.3.0"
+    yargs-parser: "npm:21.1.1"
+  peerDependencies:
+    nx: ">= 19 <= 21"
+  checksum: 10c0/40da61efd91f984cad564e6198b689492e666c85914ad37256c0e0617c2c4cd80c9c88eac3938dd448af4683ab969e8ebf1169d59e05580a82408bead75ffe33
+  languageName: node
+  linkType: hard
+
 "@nx/devkit@npm:20.0.8":
   version: 20.0.8
   resolution: "@nx/devkit@npm:20.0.8"
@@ -3296,14 +3314,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nx/jest@npm:20.1.2":
-  version: 20.1.2
-  resolution: "@nx/jest@npm:20.1.2"
+"@nx/jest@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/jest@npm:20.0.1"
   dependencies:
     "@jest/reporters": "npm:^29.4.1"
     "@jest/test-result": "npm:^29.4.1"
-    "@nx/devkit": "npm:20.1.2"
-    "@nx/js": "npm:20.1.2"
+    "@nx/devkit": "npm:20.0.1"
+    "@nx/js": "npm:20.0.1"
     "@phenomnomnominal/tsquery": "npm:~5.0.1"
     chalk: "npm:^4.1.0"
     identity-obj-proxy: "npm:3.0.0"
@@ -3315,7 +3333,50 @@ __metadata:
     semver: "npm:^7.5.3"
     tslib: "npm:^2.3.0"
     yargs-parser: "npm:21.1.1"
-  checksum: 10c0/a6552b264236b7a29d0fa6aad2c2da68b0d3af4f459be296539088f2ff09ce5afd2ee20547b8584f573fec5e5e6c524c2da7a0a83f1df6cdd8cdd694f79c4e94
+  checksum: 10c0/f96b96fe86520c09bfbe4db82a3dbe4f6e1b618dd5a28e20b59f416ef9a6b3ffa3a2290145798853fcbf674135a7e74db7ec469aa21362714e6d27379257552f
+  languageName: node
+  linkType: hard
+
+"@nx/js@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/js@npm:20.0.1"
+  dependencies:
+    "@babel/core": "npm:^7.23.2"
+    "@babel/plugin-proposal-decorators": "npm:^7.22.7"
+    "@babel/plugin-transform-class-properties": "npm:^7.22.5"
+    "@babel/plugin-transform-runtime": "npm:^7.23.2"
+    "@babel/preset-env": "npm:^7.23.2"
+    "@babel/preset-typescript": "npm:^7.22.5"
+    "@babel/runtime": "npm:^7.22.6"
+    "@nx/devkit": "npm:20.0.1"
+    "@nx/workspace": "npm:20.0.1"
+    "@zkochan/js-yaml": "npm:0.0.7"
+    babel-plugin-const-enum: "npm:^1.0.1"
+    babel-plugin-macros: "npm:^2.8.0"
+    babel-plugin-transform-typescript-metadata: "npm:^0.3.1"
+    chalk: "npm:^4.1.0"
+    columnify: "npm:^1.6.0"
+    detect-port: "npm:^1.5.1"
+    enquirer: "npm:~2.3.6"
+    fast-glob: "npm:3.2.7"
+    ignore: "npm:^5.0.4"
+    js-tokens: "npm:^4.0.0"
+    jsonc-parser: "npm:3.2.0"
+    minimatch: "npm:9.0.3"
+    npm-package-arg: "npm:11.0.1"
+    npm-run-path: "npm:^4.0.1"
+    ora: "npm:5.3.0"
+    semver: "npm:^7.5.3"
+    source-map-support: "npm:0.5.19"
+    ts-node: "npm:10.9.1"
+    tsconfig-paths: "npm:^4.1.2"
+    tslib: "npm:^2.3.0"
+  peerDependencies:
+    verdaccio: ^5.0.4
+  peerDependenciesMeta:
+    verdaccio:
+      optional: true
+  checksum: 10c0/6b4b91d7e4bb60f969f6a5dea856fd3605e205573294aaf91a690d9fad9ba16b2374cde7bcd659c060d1365f08e495b20956cc48f55b4737579e9ce6eeb18627
   languageName: node
   linkType: hard
 
@@ -3362,7 +3423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nx/js@npm:20.1.2, @nx/js@npm:^20.1.2":
+"@nx/js@npm:^20.0.1":
   version: 20.1.2
   resolution: "@nx/js@npm:20.1.2"
   dependencies:
@@ -3405,6 +3466,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nx/nx-darwin-arm64@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/nx-darwin-arm64@npm:20.0.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@nx/nx-darwin-arm64@npm:20.0.8":
   version: 20.0.8
   resolution: "@nx/nx-darwin-arm64@npm:20.0.8"
@@ -3416,6 +3484,13 @@ __metadata:
   version: 20.1.2
   resolution: "@nx/nx-darwin-arm64@npm:20.1.2"
   conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@nx/nx-darwin-x64@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/nx-darwin-x64@npm:20.0.1"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3433,6 +3508,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nx/nx-freebsd-x64@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/nx-freebsd-x64@npm:20.0.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@nx/nx-freebsd-x64@npm:20.0.8":
   version: 20.0.8
   resolution: "@nx/nx-freebsd-x64@npm:20.0.8"
@@ -3444,6 +3526,13 @@ __metadata:
   version: 20.1.2
   resolution: "@nx/nx-freebsd-x64@npm:20.1.2"
   conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-arm-gnueabihf@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/nx-linux-arm-gnueabihf@npm:20.0.1"
+  conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
@@ -3461,6 +3550,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nx/nx-linux-arm64-gnu@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/nx-linux-arm64-gnu@npm:20.0.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@nx/nx-linux-arm64-gnu@npm:20.0.8":
   version: 20.0.8
   resolution: "@nx/nx-linux-arm64-gnu@npm:20.0.8"
@@ -3472,6 +3568,13 @@ __metadata:
   version: 20.1.2
   resolution: "@nx/nx-linux-arm64-gnu@npm:20.1.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-arm64-musl@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/nx-linux-arm64-musl@npm:20.0.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -3489,6 +3592,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nx/nx-linux-x64-gnu@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/nx-linux-x64-gnu@npm:20.0.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@nx/nx-linux-x64-gnu@npm:20.0.8":
   version: 20.0.8
   resolution: "@nx/nx-linux-x64-gnu@npm:20.0.8"
@@ -3500,6 +3610,13 @@ __metadata:
   version: 20.1.2
   resolution: "@nx/nx-linux-x64-gnu@npm:20.1.2"
   conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@nx/nx-linux-x64-musl@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/nx-linux-x64-musl@npm:20.0.1"
+  conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
@@ -3517,6 +3634,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nx/nx-win32-arm64-msvc@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/nx-win32-arm64-msvc@npm:20.0.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@nx/nx-win32-arm64-msvc@npm:20.0.8":
   version: 20.0.8
   resolution: "@nx/nx-win32-arm64-msvc@npm:20.0.8"
@@ -3531,6 +3655,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nx/nx-win32-x64-msvc@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/nx-win32-x64-msvc@npm:20.0.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@nx/nx-win32-x64-msvc@npm:20.0.8":
   version: 20.0.8
   resolution: "@nx/nx-win32-x64-msvc@npm:20.0.8"
@@ -3542,6 +3673,20 @@ __metadata:
   version: 20.1.2
   resolution: "@nx/nx-win32-x64-msvc@npm:20.1.2"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@nx/workspace@npm:20.0.1":
+  version: 20.0.1
+  resolution: "@nx/workspace@npm:20.0.1"
+  dependencies:
+    "@nx/devkit": "npm:20.0.1"
+    chalk: "npm:^4.1.0"
+    enquirer: "npm:~2.3.6"
+    nx: "npm:20.0.1"
+    tslib: "npm:^2.3.0"
+    yargs-parser: "npm:21.1.1"
+  checksum: 10c0/662814e868de6f2964a15c47f5e3359d9d092cd68eda03ed6e31a17357dd8921385669888741f157700dfbeeaec0323604d55ed2bf5a9e036323357fb91c051a
   languageName: node
   linkType: hard
 
@@ -8671,14 +8816,14 @@ __metadata:
   resolution: "lambdas@workspace:."
   dependencies:
     "@nx/eslint": "npm:20.0.8"
-    "@nx/jest": "npm:20.1.2"
-    "@nx/js": "npm:^20.1.2"
+    "@nx/jest": "npm:20.0.1"
+    "@nx/js": "npm:^20.0.1"
     "@swc-node/register": "npm:~1.10.9"
     "@swc/core": "npm:~1.7.40"
     "@swc/helpers": "npm:~0.5.15"
     eslint: "npm:^8.57.0"
     jest: "npm:^29.7.0"
-    nx: "npm:20.1.2"
+    nx: "npm:20.0.1"
     prettier: "npm:^3.3.3"
     typescript: "npm:^5.6.3"
   languageName: unknown
@@ -9274,6 +9419,88 @@ __metadata:
   dependencies:
     path-key: "npm:^3.0.0"
   checksum: 10c0/6f9353a95288f8455cf64cbeb707b28826a7f29690244c1e4bb61ec573256e021b6ad6651b394eb1ccfd00d6ec50147253aba2c5fe58a57ceb111fad62c519ac
+  languageName: node
+  linkType: hard
+
+"nx@npm:20.0.1":
+  version: 20.0.1
+  resolution: "nx@npm:20.0.1"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:0.2.4"
+    "@nx/nx-darwin-arm64": "npm:20.0.1"
+    "@nx/nx-darwin-x64": "npm:20.0.1"
+    "@nx/nx-freebsd-x64": "npm:20.0.1"
+    "@nx/nx-linux-arm-gnueabihf": "npm:20.0.1"
+    "@nx/nx-linux-arm64-gnu": "npm:20.0.1"
+    "@nx/nx-linux-arm64-musl": "npm:20.0.1"
+    "@nx/nx-linux-x64-gnu": "npm:20.0.1"
+    "@nx/nx-linux-x64-musl": "npm:20.0.1"
+    "@nx/nx-win32-arm64-msvc": "npm:20.0.1"
+    "@nx/nx-win32-x64-msvc": "npm:20.0.1"
+    "@yarnpkg/lockfile": "npm:^1.1.0"
+    "@yarnpkg/parsers": "npm:3.0.0-rc.46"
+    "@zkochan/js-yaml": "npm:0.0.7"
+    axios: "npm:^1.7.4"
+    chalk: "npm:^4.1.0"
+    cli-cursor: "npm:3.1.0"
+    cli-spinners: "npm:2.6.1"
+    cliui: "npm:^8.0.1"
+    dotenv: "npm:~16.4.5"
+    dotenv-expand: "npm:~11.0.6"
+    enquirer: "npm:~2.3.6"
+    figures: "npm:3.2.0"
+    flat: "npm:^5.0.2"
+    front-matter: "npm:^4.0.2"
+    ignore: "npm:^5.0.4"
+    jest-diff: "npm:^29.4.1"
+    jsonc-parser: "npm:3.2.0"
+    lines-and-columns: "npm:2.0.3"
+    minimatch: "npm:9.0.3"
+    node-machine-id: "npm:1.1.12"
+    npm-run-path: "npm:^4.0.1"
+    open: "npm:^8.4.0"
+    ora: "npm:5.3.0"
+    semver: "npm:^7.5.3"
+    string-width: "npm:^4.2.3"
+    tar-stream: "npm:~2.2.0"
+    tmp: "npm:~0.2.1"
+    tsconfig-paths: "npm:^4.1.2"
+    tslib: "npm:^2.3.0"
+    yargs: "npm:^17.6.2"
+    yargs-parser: "npm:21.1.1"
+  peerDependencies:
+    "@swc-node/register": ^1.8.0
+    "@swc/core": ^1.3.85
+  dependenciesMeta:
+    "@nx/nx-darwin-arm64":
+      optional: true
+    "@nx/nx-darwin-x64":
+      optional: true
+    "@nx/nx-freebsd-x64":
+      optional: true
+    "@nx/nx-linux-arm-gnueabihf":
+      optional: true
+    "@nx/nx-linux-arm64-gnu":
+      optional: true
+    "@nx/nx-linux-arm64-musl":
+      optional: true
+    "@nx/nx-linux-x64-gnu":
+      optional: true
+    "@nx/nx-linux-x64-musl":
+      optional: true
+    "@nx/nx-win32-arm64-msvc":
+      optional: true
+    "@nx/nx-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc-node/register":
+      optional: true
+    "@swc/core":
+      optional: true
+  bin:
+    nx: bin/nx.js
+    nx-cloud: bin/nx-cloud.js
+  checksum: 10c0/6a0fbe0b438b30a3bb0eefde685377bdc2a5547509e3273cf20d97d1acdde2aba190560739ccf419452f312e90dc4abeba9dcee01348aa6d6378d39137fc47e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

For some reasn the nx build was borken on mac. Fixed by ensuring all nx dependency are aligned (yarn dedupe) and added a nx group for dependabot.