### PR TITLE
fix!: remove deprecated runners_scale_up_Lambda_memory_size as it breaks CDKTF

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -240,7 +240,7 @@ module "runners" {
   lambda_runtime                   = var.lambda_runtime
   lambda_architecture              = var.lambda_architecture
   lambda_zip                       = var.runners_lambda_zip
-  lambda_scale_up_memory_size      = coalesce(var.runners_scale_up_Lambda_memory_size, var.runners_scale_up_lambda_memory_size)
+  lambda_scale_up_memory_size      = var.runners_scale_up_lambda_memory_size
   lambda_scale_down_memory_size    = var.runners_scale_down_lambda_memory_size
   lambda_timeout_scale_up          = var.runners_scale_up_lambda_timeout
   lambda_timeout_scale_down        = var.runners_scale_down_lambda_timeout

--- a/variables.deprecated.tf
+++ b/variables.deprecated.tf
@@ -21,14 +21,6 @@ variable "enable_event_rule_binaries_syncer" {
   }
 }
 
-
-# tflint-ignore: terraform_naming_convention
-variable "runners_scale_up_Lambda_memory_size" {
-  description = "Memory size limit in MB for scale-up lambda."
-  type        = number
-  default     = null
-}
-
 # tflint-ignore: terraform_unused_declarations
 variable "enable_metrics_control_plane" {
   description = "(Experimental) Enable or disable the metrics for the module. Feature can change or renamed without a major release."


### PR DESCRIPTION
Hi. Thanks for this module.

I come from a CDKTF shop. CDKTF basically has a code generator based on the HCL code which generates the appropriate objects and types.

TypeScript uses camel case as default convention for symbols so that code generator produces invalid code as both the current `runners_scale_up_lambda_memory_size` and the legacy `runners_scale_up_Lambda_memory_size` are converted to the same camel cased string and the TypeScript compiler rejects that code when imported as it contains duplicate symbols.

Removing this deprecated variable enables the CDKTF users who run into this problem to successfully use this module.

This is a breaking change but I don't know for how long you do keep deprecated vars.