### PR TITLE
feat(packer): Allow passing in an instance_profile and custom shell scripts that run after the runner installation

### DIFF
--- a/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
@@ -42,6 +42,12 @@ variable "instance_type" {
   default     = "t3.medium"
 }
 
+variable "iam_instance_profile" {
+  description = "IAM instance profile Packer will use for the builder. An empty string (default) means no profile will be assigned."
+  type        = string
+  default     = ""
+}
+
 variable "root_volume_size_gb" {
   type    = number
   default = 8
@@ -77,6 +83,12 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+variable "custom_shell_commands_post_runner_install" {
+  description = "Additional commands to run on the EC2 instance, to customize the instance, like installing packages. This runs after the agent is installed."
+  type        = list(string)
+  default     = []
+}
+
 variable "temporary_security_group_source_public_ip" {
   description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group. Note: If you specify `security_group_id` then this input is ignored."
   type        = bool
@@ -98,6 +110,7 @@ locals {
 source "amazon-ebs" "githubrunner" {
   ami_name                                  = "github-runner-ubuntu-focal-amd64-${formatdate("YYYYMMDDhhmm", timestamp())}"
   instance_type                             = var.instance_type
+  iam_instance_profile                      = var.iam_instance_profile
   region                                    = var.region
   security_group_id                         = var.security_group_id
   subnet_id                                 = var.subnet_id
@@ -200,6 +213,12 @@ build {
       "sudo chmod +x /var/lib/cloud/scripts/per-boot/start-runner.sh",
     ]
   }
+
+  provisioner "shell" {
+    environment_vars = []
+    inline           = concat(var.custom_shell_commands_post_runner_install)
+  }
+
   post-processor "manifest" {
     output     = "manifest.json"
     strip_path = true

--- a/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
@@ -42,6 +42,12 @@ variable "instance_type" {
   default     = "t4g.small"
 }
 
+variable "iam_instance_profile" {
+  description = "IAM instance profile Packer will use for the builder. An empty string (default) means no profile will be assigned."
+  type        = string
+  default     = ""
+}
+
 variable "root_volume_size_gb" {
   type    = number
   default = 8
@@ -77,6 +83,12 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+variable "custom_shell_commands_post_runner_install" {
+  description = "Additional commands to run on the EC2 instance, to customize the instance, like installing packages. This runs after the agent is installed."
+  type        = list(string)
+  default     = []
+}
+
 variable "temporary_security_group_source_public_ip" {
   description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group. Note: If you specify `security_group_id` then this input is ignored."
   type        = bool
@@ -98,6 +110,7 @@ locals {
 source "amazon-ebs" "githubrunner" {
   ami_name                                  = "github-runner-ubuntu-jammy-arm64-${formatdate("YYYYMMDDhhmm", timestamp())}"
   instance_type                             = var.instance_type
+  iam_instance_profile                      = var.iam_instance_profile
   region                                    = var.region
   security_group_id                         = var.security_group_id
   subnet_id                                 = var.subnet_id

--- a/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
@@ -213,6 +213,12 @@ build {
       "sudo chmod +x /var/lib/cloud/scripts/per-boot/start-runner.sh",
     ]
   }
+
+  provisioner "shell" {
+    environment_vars = []
+    inline           = concat(var.custom_shell_commands_post_runner_install)
+  }
+
   post-processor "manifest" {
     output     = "manifest.json"
     strip_path = true

--- a/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
@@ -42,6 +42,12 @@ variable "instance_type" {
   default     = "t3.medium"
 }
 
+variable "iam_instance_profile" {
+  description = "IAM instance profile Packer will use for the builder. An empty string (default) means no profile will be assigned."
+  type        = string
+  default     = ""
+}
+
 variable "root_volume_size_gb" {
   type    = number
   default = 8
@@ -77,6 +83,12 @@ variable "custom_shell_commands" {
   default     = []
 }
 
+variable "custom_shell_commands_post_runner_install" {
+  description = "Additional commands to run on the EC2 instance, to customize the instance, like installing packages. This runs after the agent is installed."
+  type        = list(string)
+  default     = []
+}
+
 variable "temporary_security_group_source_public_ip" {
   description = "When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com) as CIDR block to be authorized access to the instance, when packer is creating a temporary security group. Note: If you specify `security_group_id` then this input is ignored."
   type        = bool
@@ -98,6 +110,7 @@ locals {
 source "amazon-ebs" "githubrunner" {
   ami_name                                  = "github-runner-ubuntu-jammy-amd64-${formatdate("YYYYMMDDhhmm", timestamp())}"
   instance_type                             = var.instance_type
+  iam_instance_profile                      = var.iam_instance_profile
   region                                    = var.region
   security_group_id                         = var.security_group_id
   subnet_id                                 = var.subnet_id
@@ -200,6 +213,12 @@ build {
       "sudo chmod +x /var/lib/cloud/scripts/per-boot/start-runner.sh",
     ]
   }
+
+  provisioner "shell" {
+    environment_vars = []
+    inline           = concat(var.custom_shell_commands_post_runner_install)
+  }
+
   post-processor "manifest" {
     output     = "manifest.json"
     strip_path = true


### PR DESCRIPTION
We ran into a couple obstacles when building our custom AMIs. One was needing to pass a custom instance profile to packer in order to get AWS IAM credentials for pre-pulling some ECR images. The other was wanting to run some custom build scripts after the agent had already been installed.

One of our primary reasons for the custom script after agent installation was to write the `ACTIONS_RUNNER_HOOK_JOB_STARTED=` environment variable to the `/opt/actions-runner/.env` file pointing to some cleanup scripts we lay down on disk during AMI building. This may be taken care of if https://github.com/philips-labs/terraform-aws-github-runner/pull/4263 ends up merging, but we have another couple smaller things we're doing to configure the agent installation directory.

I noticed what I think was a missing `instance_type` override variable in the windows-core-2022 file. I'm not sure if that was an oversight, or if it was omitted for a reason. It's been a long time since I've been proficient in Windows, so I wasn't able to test that part of this very well. Because the windows script seemed to already execute after agent installation, I thought it made sense to have the same input variables for all the profiles, and to just run this script directly after the other custom_shell_script that already exists. I thought it safer to make this additional variable instead of moving the custom_shell_script to after agent installation just in case that caused unforeseen issues for others. That being said, we're only using the custom script after agent installation, so moving the existing script to run after agent installation would also solve our problem.

Thanks so much for this project, this has been immensely beneficial for us.