### PR TITLE
[DEV-118047] Migrate docker-compose images to private ECR registry

### DIFF
--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         node: [20]
     container:
-      image: node:${{ matrix.node }}
+      image: 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/docker/library/node:${{ matrix.node }}
     defaults:
       run:
         working-directory: ./lambdas

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -16,7 +16,7 @@ jobs:
     name: Verify packer
     runs-on: ubuntu-latest
     container:
-      image: index.docker.io/hashicorp/packer@sha256:297bbbbbbf3ce9e0431ac1e8f02934b20e1197613f877b55dfdb1ebfd94eb748 # ratchet:index.docker.io/hashicorp/packer:1.8.6
+      image: 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/hashicorp/packer@sha256:297bbbbbbf3ce9e0431ac1e8f02934b20e1197613f877b55dfdb1ebfd94eb748 # ratchet:index.docker.io/hashicorp/packer:1.8.6
     strategy:
       matrix:
         image: ["linux-al2023", "windows-core-2019", "windows-core-2022", "ubuntu-focal", "ubuntu-jammy", "ubuntu-jammy-arm64"]

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,7 +20,7 @@ jobs:
         terraform: [1.5.6, "latest"]
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/terraform:${{ matrix.terraform }}
+      image: 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/hashicorp/terraform:${{ matrix.terraform }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
@@ -87,7 +87,7 @@ jobs:
         working-directory: modules/${{ matrix.module }}
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/terraform:${{ matrix.terraform }}
+      image: 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/hashicorp/terraform:${{ matrix.terraform }}
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: terraform init
@@ -145,7 +145,7 @@ jobs:
         working-directory: examples/${{ matrix.example }}
     runs-on: ubuntu-latest
     container:
-      image: hashicorp/terraform:${{ matrix.terraform }}
+      image: 290268990387.dkr.ecr.us-west-2.amazonaws.com/ecr-public/hashicorp/terraform:${{ matrix.terraform }}
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
       - name: terraform init


### PR DESCRIPTION
As part of our migration out of Dockerhub, this PR moves existing image references in the docker-compose that we are now mirroring in our private ECR.