### PR TITLE
Added debug for queued events function

### DIFF
--- a/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
+++ b/lambdas/functions/control-plane/src/scale-runners/scale-up.ts
@@ -148,6 +148,12 @@ export async function isJobQueued(githubInstallationClient: Octokit, payload: Ac
     });
     metricGitHubAppRateLimit(jobForWorkflowRun.headers);
     isQueued = jobForWorkflowRun.data.status === 'queued';
+    if (!isQueued) {
+      logger.info(`Job ${payload.id} is not queued`);
+    }
+    else {
+      logger.info(`Job ${payload.id} is queued`);
+    }
   } else {
     throw Error(`Event ${payload.eventType} is not supported`);
   }


### PR DESCRIPTION
When working out a job is queued or not, we do it within a function. However, when we do it within this function there is very little ability to see what the response was when debugging is enabled. So this PR is allowing us to see what was determined from the function.  