### PR TITLE
feat: Make Packer builder IAM role configurable

### DIFF
--- a/images/linux-al2023/github_agent.linux.pkr.hcl
+++ b/images/linux-al2023/github_agent.linux.pkr.hcl
@@ -42,6 +42,12 @@ variable "instance_type" {
   default     = "m3.medium"
 }
 
+variable "iam_instance_profile" {
+  description = "The IAM instance profile to run the builder as"
+  type        = string
+  default     = ""
+}
+
 variable "root_volume_size_gb" {
   type    = number
   default = 8
@@ -103,6 +109,7 @@ source "amazon-ebs" "githubrunner" {
   subnet_id                                 = var.subnet_id
   associate_public_ip_address               = var.associate_public_ip_address
   temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
+  iam_instance_profile                      = var.iam_instance_profile
 
   source_ami_filter {
     filters = {

--- a/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-focal/github_agent.ubuntu.pkr.hcl
@@ -42,6 +42,12 @@ variable "instance_type" {
   default     = "t3.medium"
 }
 
+variable "iam_instance_profile" {
+  description = "The IAM instance profile to run the builder as"
+  type        = string
+  default     = ""
+}
+
 variable "root_volume_size_gb" {
   type    = number
   default = 8
@@ -103,6 +109,7 @@ source "amazon-ebs" "githubrunner" {
   subnet_id                                 = var.subnet_id
   associate_public_ip_address               = var.associate_public_ip_address
   temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
+  iam_instance_profile                      = var.iam_instance_profile
 
   source_ami_filter {
     filters = {

--- a/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy-arm64/github_agent.ubuntu.pkr.hcl
@@ -42,6 +42,12 @@ variable "instance_type" {
   default     = "t4g.small"
 }
 
+variable "iam_instance_profile" {
+  description = "The IAM instance profile to run the builder as"
+  type        = string
+  default     = ""
+}
+
 variable "root_volume_size_gb" {
   type    = number
   default = 8
@@ -103,6 +109,7 @@ source "amazon-ebs" "githubrunner" {
   subnet_id                                 = var.subnet_id
   associate_public_ip_address               = var.associate_public_ip_address
   temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
+  iam_instance_profile                      = var.iam_instance_profile
 
   source_ami_filter {
     filters = {

--- a/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
@@ -42,6 +42,12 @@ variable "instance_type" {
   default     = "t3.medium"
 }
 
+variable "iam_instance_profile" {
+  description = "The IAM instance profile to run the builder as"
+  type        = string
+  default     = ""
+}
+
 variable "root_volume_size_gb" {
   type    = number
   default = 8
@@ -103,6 +109,7 @@ source "amazon-ebs" "githubrunner" {
   subnet_id                                 = var.subnet_id
   associate_public_ip_address               = var.associate_public_ip_address
   temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
+  iam_instance_profile                      = var.iam_instance_profile
 
   source_ami_filter {
     filters = {

--- a/images/windows-core-2019/github_agent.windows.pkr.hcl
+++ b/images/windows-core-2019/github_agent.windows.pkr.hcl
@@ -24,6 +24,12 @@ variable "instance_type" {
   default     = "t3a.medium"
 }
 
+variable "iam_instance_profile" {
+  description = "The IAM instance profile to run the builder as"
+  type        = string
+  default     = ""
+}
+
 variable "ebs_delete_on_termination" {
   description = "Indicates whether the EBS volume is deleted on instance termination."
   type        = bool
@@ -67,6 +73,7 @@ source "amazon-ebs" "githubrunner" {
   region                                    = var.region
   associate_public_ip_address               = var.associate_public_ip_address
   temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
+  iam_instance_profile                      = var.iam_instance_profile
 
   source_ami_filter {
     filters = {

--- a/images/windows-core-2022/github_agent.windows.pkr.hcl
+++ b/images/windows-core-2022/github_agent.windows.pkr.hcl
@@ -24,6 +24,12 @@ variable "security_group_id" {
   default     = null
 }
 
+variable "iam_instance_profile" {
+  description = "The IAM instance profile to run the builder as"
+  type        = string
+  default     = ""
+}
+
 variable "subnet_id" {
   description = "If using VPC, the ID of the subnet, such as subnet-12345def, where Packer will launch the EC2 instance. This field is required if you are using an non-default VPC"
   type        = string
@@ -80,6 +86,7 @@ source "amazon-ebs" "githubrunner" {
   subnet_id                                 = var.subnet_id
   associate_public_ip_address               = var.associate_public_ip_address
   temporary_security_group_source_public_ip = var.temporary_security_group_source_public_ip
+  iam_instance_profile                      = var.iam_instance_profile
 
   source_ami_filter {
     filters = {


### PR DESCRIPTION
Allows the Packer build instance to access resources as a IAM role during the build process. Defaults to empty string, which should replicate existing behaviour.

See #3041.